### PR TITLE
Downloaded folder created on first module download

### DIFF
--- a/cmds/system/download.js
+++ b/cmds/system/download.js
@@ -33,10 +33,14 @@ exports.run = (client, msg, [url]) => {
             }
             let name = mod.exports.help.name;
             let description = mod.exports.help.description;
+            let dir ="./cmds/downloaded/";
             client.log(`New Command: ${name} / ${description}`);
-            fs.writeFile(`./cmds/Downloaded/${name}.js`, res.text, (err) => {
+            if (!fs.existsSync(dir)) {
+              fs.mkdirSync(dir);
+            }
+            fs.writeFile(`${dir}${name}.js`, res.text, (err) => {
               if(err) console.error(err);
-              client.funcs.loadNewCommand(client, `Downloaded/${name}.js`)
+              client.funcs.loadNewCommand(client, `downloaded/${name}.js`)
                 .then(() => {
                   m.edit(`Successfully Loaded: ${name}`);
                 })


### PR DESCRIPTION
The download command throws errors if you do not manually create the "Downloaded" folder, following naming conventions, I've added a few lines to create "downloaded" on the first download attempt.
