### PR TITLE
changed fetchMessage to fetchMessages

### DIFF
--- a/functions/inhibitors/usage.js
+++ b/functions/inhibitors/usage.js
@@ -52,9 +52,10 @@ exports.run = (client, msg, cmd) => {
           case "msg":
           case "message":
             if (/^\d+$/.test(args[i])) {
-              msg.channel.fetchMessage(args[i])
+              msg.channel.fetchMessages({ around: args[i] })
                 .then(m => {
-                  args[i] = m;
+                  args[i] = m.filter(e => e.id == args[i]).first();
+                  // args[i] = m;
                   validateArgs(++i);
                 })
                 .catch(() => {


### PR DESCRIPTION
Since fetchMessage (singular) is oauth bot only, selfbots would of been borderline impossible / problematic, using fetchMessages (plural) and filter by ID replicated fetchMessage (singular)'s functionality with minimal response impact.
