### PR TITLE
Fixed LoadFunc

### DIFF
--- a/functions/loadFunctions.js
+++ b/functions/loadFunctions.js
@@ -17,6 +17,7 @@ module.exports = client => {
 const loadFunctions = (client, baseDir, counts) => {
   return new Promise( (resolve, reject) => {
     let dir = path.resolve(baseDir + "./functions/");
+    fs.ensureDirSync(dir);
     fs.readdir(dir, (err, files) => {
       if (err) reject(err);
       files = files.filter(f => { return f.slice(-3) === ".js"; });


### PR DESCRIPTION
Fixed the initial load of Komada due to LoadFunctions not having a ensureDir

ensureDirSync has been added before the readdir to fix this issue.
