### PR TITLE
Indev (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ komada.start({
   "commandInhibitors": ["disable", "permissions", "missingBotPermissions"],
   "dataHandlers": [],
   "clientOptions": {
-    forceFetchUsers: true
+    "fetchAllMembers": true
   }
 });
 ```
@@ -45,3 +45,121 @@ node app.js
 ```
 
 > Requires Node 6 or higher (because discord.js requires that), also requires Discord.js v10 (currently #indev), installed automatically with `npm install`.
+
+## Quick & Dirty Reference Guide
+> For creating your own pieces
+
+Essentially, the way Komada works is that we have *core* pieces (functions, events, commands, etc) loaded automatically. 
+But you can add your own pieces easily by adding files to your *local* folders (which are created on first load)
+
+These pieces are: 
+- **Commands** which add in-chat functionality to your bot
+- **functions** which can be used by other pieces or anywhere in the bot.
+- **dataHandlers** which are database connectors (in progress at the moment)
+
+### Creating a new command
+
+New commands are created in the `./commands/` folder, where subfolders are
+the categories offered in the help command. For instance adding `./commands/Misc/test.js`
+will create a command named `test` in the `Misc` category. Subcategories can
+also be created by adding a second folder level.
+
+> If a command is present both in the *core* folders and your client folders, 
+your command will override the core one. This can let you modify the core
+behaviour. Note also that you cannot have more than one command with the same name.
+
+```js
+exports.run = (client, msg. [...args]) => {
+  // Place Code Here
+};
+
+exports.conf = {
+  enabled: true,
+  guildOnly: true,
+  aliases: [],
+  permLevel: 0,
+  botPerms: [],
+  requiredFuncs: []
+};
+
+exports.help = {
+  name: "name",
+  description: "Command Description",
+  usage: "",
+  usageDelim: ""
+};
+```
+
+`[...args]` represents a variable number of arguments give when the command is
+run. The name of the arguments in the array (and their count) is determined
+by the `usage` property and its given arguments.
+
+**Non-obvious options**: 
+- **enabled**: Set to false to completely disable this command, it cannot be forecefully enabled.
+- **aliases**: Array of aliases for the command, which will *also* trigger it.
+- **permLevel**: Permission level, controlled via `./functions/permissionLevel.js`
+- **botPerms**: An array of permission strings (such as `"MANAGE_MESSAGES"`) required for the command to run.
+- **requiredFuncs**: An array of function names required for this command to execute (dependency)
+- **usage**: The usage string as determined by the Argument Usage (see below)
+
+#### Command Arguments
+
+** Usage Structure **
+`<>` required argument, `[]` optional argument
+`<Name:Type{min,max}>`
+
+- **Name** Mostly used for debugging message, unless the type is Litteral in which it compares the argument to the name.
+- **Type** The type of variable you are expecting
+- **Min, Max** Minimum or Maximum for a giving variable (works on strings in terms of length, and on all types of numbers in terms of value) You are allowed to define any combination of min and max. Omit for none, `{min}` for min, `{,max}` for max.
+- **Special Repeat Tag** `[...]` will repeat the last usage optionally until you run out of arguments. Useful for doing something like `<SearchTerm:str> [...]` which will allow you to take as many search terms as you want, per your Usage Deliminator.
+
+**Usage Types**
+- `literal` : Literally equal to the Name. This is the default type if none is defined.
+- `str`, `string` : Strings
+- `int`, `integer` : Integers
+- `num`, `number`, `Float` : Floating point numbers
+- `url` : a url
+- `msg`, `message` : A message object returned from the message id (now using fetchMessage as of d3d498c99d5eca98b5cbcefb9838fa7d96f17c93)
+- `channel` : A channel object returned from the channel id or channel tag
+- `guild` : A guild object returned from the guild id
+- `user`, `mention` : A user object returned from the user id or mention
+ 
+### Creating an event
+
+Events are placed in `./events/` and their filename must be `eventName.js`.
+If a conflicting event is present in both the core and your client, *both* are
+loaded and will run when that event is triggered.
+
+Their structure is the following :
+
+```js
+exports.run = (client, [...args]) => {
+  // event contents
+};
+```
+
+Where `[...args]` is arguments you would *normally* get from those events.
+For example, while the `ready` event would only have `(client)`, the 
+`guildMemberAdd` event would be `(guild, member)`.
+
+### Creating a function
+
+Functions are available throughout the system, from anywhere. Since they are the
+first thing loaded, every other piece can access them. Functions are loaded as
+core first, and if your code contains a function of the same name it overrides
+the core function.
+
+Their structure is somewhat freeform, in that they can contain a single function,
+or they may be a module composed of more than one functions as a module. It's
+not supposed to, but let's keep it between you and me, alright?
+
+```js
+module.exports = (str) => {
+  return str.replace(/\w\S*/g, function(txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+};
+```
+
+The arguments are arbitrary - just like a regular function. It may, or may not,
+return anything. Basically any functions. You know what I mean.

--- a/app.js
+++ b/app.js
@@ -1,11 +1,10 @@
 const Discord = require("discord.js");
-const fs = require("fs-extra");
 const chalk = require("chalk");
 const clk = new chalk.constructor({ enabled: true });
 
 exports.start = (config) => {
 
-  const client = new Discord.Client(config.discordOptions);
+  const client = new Discord.Client(config.clientOptions);
 
   client.config = config;
 
@@ -22,56 +21,31 @@ exports.start = (config) => {
   client.clientBaseDir = process.cwd() + "/";
 
   // Load core functions, then everything else
-  client.funcs["loadFunctions"] = () => {
-    fs.readdir(__dirname + "/functions", (err, files) => {
-      if (err) console.error(err);
-      files = files.filter(f => { return f.slice(-3) === ".js"; });
-      let [d,o] = [0,0];
-      files.forEach(f=> {
-        let file = f.split(".");
-        if (file[1] !== "opt") {
-          client.funcs[file[0]] = require(`./functions/${f}`);
-          d++;
-        } else if (client.config.functions.includes(file[0])) {
-          client.funcs[file[0]] = require(`./functions/${f}`);
-          o++;
-        }
-      });
-      client.funcs.log(`Loaded ${d} functions, with ${o} optional.`);
-      client.funcs.loadDataProviders(client);
-      client.funcs.loadCommands(client);
-      client.funcs.loadCommandInhibitors(client);
-      client.funcs.loadEvents(client);
-    });
-  };
-  client.funcs.loadFunctions();
-  let clientFunctionsDir = require("path").resolve(client.clientBaseDir + "./functions");
-  fs.ensureDir(clientFunctionsDir, err => {
-    if (err) console.error(err);
-    fs.readdir(clientFunctionsDir, (err, files) => {
-      if (err) console.error(err);
-      files = files.filter(f => { return f.slice(-3) === ".js"; });
-      let [d,o] = [0,0];
-      files.forEach(f=> {
-        let file = f.split(".");
-        if (file[1] !== "opt") {
-          client.funcs[file[0]] = require(`${clientFunctionsDir}/${f}`);
-          d++;
-        } else if (client.config.functions.includes(file[0])) {
-          client.funcs[file[0]] = require(`${clientFunctionsDir}/${f}`);
-          o++;
-        }
-      });
-    });
+  require("./functions/loadFunctions.js")(client).then(() => {
+    client.funcs.loadDataProviders(client);
+    client.funcs.loadCommands(client);
+    client.funcs.loadCommandInhibitors(client);
+    client.funcs.loadEvents(client);
   });
 
   client.once("ready", () => {
     client.config.prefixMention = new RegExp(`^<@!?${client.user.id}>`);
+    client.funcs.confs.init(client);
+  });
+
+  client.once("confsRead", () => {
+    client.commands.forEach(command => {
+      if(command.init) {
+        command.init(client);
+      }
+    });
   });
 
   client.on("message", msg => {
-    if (!msg.content.startsWith(client.config.prefix) && !client.config.prefixMention.test(msg.content)) return;
-    let prefixLength = client.config.prefix.length;
+    let conf = client.funcs.confs.get(msg.guild);
+    msg.guildConf = conf;
+    if (!msg.content.startsWith(conf.prefix) && !client.config.prefixMention.test(msg.content)) return;
+    let prefixLength = conf.prefix.length;
     if(client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length +1;
     let command = msg.content.slice(prefixLength).split(" ")[0].toLowerCase();
     let suffix = msg.content.slice(prefixLength).split(" ").slice(1).join(" ");

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -1,0 +1,40 @@
+exports.run = (client, msg, [action, key, value]) => {
+  if(action === "list") {
+    msg.channel.sendCode("json", require("util").inspect(msg.guildConf));
+    return;
+  } else
+
+  if(action === "get") {
+    if(!key) return msg.reply("Please provide a key you wish to view");
+    msg.reply(`The value for ${key} is currently: ${msg.guildConf[key]}`);
+    return;
+  } else
+
+  if(action === "set") {
+    if(!key || !value) return msg.reply("Please provide both a key and value!");
+    client.funcs.confs.set(msg.guild, key, value);
+    return msg.reply(`The value for ${key} has been set to: ${value}`);
+  } else
+
+  if(action === "reset") {
+    if(!key) return msg.reply("Please provide a key you wish to reset");
+    client.funcs.confs.resetKey(msg.guild, key);
+    return msg.reply("The key has been reset.");
+  }
+};
+
+exports.conf = {
+  enabled: true,
+  guildOnly: false,
+  aliases: [],
+  permLevel: 3,
+  botPerms: [],
+  requiredFuncs: []
+};
+
+exports.help = {
+  name: "conf",
+  description: "Define per-server configuration.",
+  usage: "<set|get|reset|list> [key:str] [channel:channel|user:user|int:int|str:str]",
+  usageDelim: " "
+};

--- a/commands/System/eval.js
+++ b/commands/System/eval.js
@@ -3,8 +3,9 @@ exports.run = (client, msg, [code]) => {
     var evaled = eval(code);
     if (typeof evaled !== "string")
       evaled = require("util").inspect(evaled);
-    msg.channel.sendCode("xl",client.funcs.clean(evaled));
-  } catch (err) {
+    msg.channel.sendCode("xl", client.funcs.clean(client, evaled));
+  }
+  catch (err) {
     msg.channel.sendMessage("`ERROR` ```xl\n" +
       client.funcs.clean(err) +
       "\n```");

--- a/commands/System/help.js
+++ b/commands/System/help.js
@@ -6,9 +6,7 @@ exports.run = (client, msg, [cmd]) => {
       helpMessage.push(`**${category} Commands**: \`\`\`asciidoc`);
       for(let [subCategory, commands] of subCategories) {
         helpMessage.push(`= ${subCategory} =`);
-        client.funcs.log(`There are ${commands.size} commands in ${subCategory}`);
         for(let [command, description] of commands) {
-          client.funcs.log(`Help command for ${command} :: ${description}`);
           helpMessage.push(`${command} :: ${description}`);
         }
         helpMessage.push(" ");

--- a/commands/System/invite.js
+++ b/commands/System/invite.js
@@ -11,8 +11,8 @@ exports.help = {
 };
 
 exports.conf = {
-  enabled: false,
-  guildOnly: false,
+  enabled: true,
+  guildOnly: true,
   aliases: [],
   permLevel: 0,
   botPerms: [],

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,0 +1,4 @@
+exports.run = (client, guild) => {
+  if(!guild.available) return;
+  client.funcs.confs.add(client, guild);
+};

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,0 +1,4 @@
+exports.run = (client, guild) => {
+  if(!guild.available) return;
+  client.funcs.confs.remove(client, guild);
+};

--- a/functions/clean.js
+++ b/functions/clean.js
@@ -1,7 +1,19 @@
-module.exports = (text) => {
+module.exports = (client, text) => {
   if (typeof(text) === "string") {
-    return text.replace(/`/g, "`" + String.fromCharCode(8203)).replace(/@/g, "@" + String.fromCharCode(8203));
+    return text.replace(sensitivePattern(client), "「ｒｅｄａｃｔｅｄ」").replace(client.user.email, '「ｒｅｄａｃｔｅｄ」').replace(/`/g, "`" + String.fromCharCode(8203)).replace(/@/g, "@" + String.fromCharCode(8203));
   } else {
     return text;
   }
+};
+
+function sensitivePattern(client) {
+  if (!this._sensitivePattern) {
+    let pattern = '';
+    if (client.token) pattern += client.token;
+    if (client.token) pattern += (pattern.length > 0 ? '|' : '') + client.token;
+    if (client.email) pattern += (pattern.length > 0 ? '|' : '') + client.email;
+    if (client.password) pattern += (pattern.length > 0 ? '|' : '') + client.password;
+    this._sensitivePattern = new RegExp(pattern, 'gi');
+  }
+  return this._sensitivePattern;
 };

--- a/functions/confs.js
+++ b/functions/confs.js
@@ -1,0 +1,147 @@
+const fs = require("fs-extra");
+const path = require("path");
+const guildConfs = new Map();
+let dataDir = "";
+let defaultFile = "default.json";
+let defaultConf = {};
+
+exports.init = (client) => {
+  dataDir = path.resolve(`${client.clientBaseDir}${path.sep}bwd${path.sep}conf`);
+
+  // Load default configuration, create if not exist.
+  defaultConf = {
+    prefix: {type: "str", data: client.config.prefix},
+    disabledCommands: {type: "array", data: "[]"}
+  };
+
+  fs.ensureFileSync(dataDir + path.sep + defaultFile);
+  try {
+    defaultConf = fs.readJSONSync(path.resolve(dataDir + path.sep + defaultFile));
+  } catch(e) {
+    fs.outputJSONSync(dataDir + path.sep + defaultFile, defaultConf);
+  }
+
+  fs.walk(dataDir)
+  .on("data", (item) => {
+    let fileinfo = path.parse(item.path);
+    if(!fileinfo.ext) return;
+    if(fileinfo.name == "default") return;
+    const guildID = fileinfo.name;
+    const thisConf = fs.readJSONSync(path.resolve(dataDir + path.sep + fileinfo.base));
+    guildConfs.set(guildID, thisConf);
+  })
+  .on("end", () => {
+    client.emit("confsRead");
+  });
+};
+
+exports.remove = (guild) => {
+  if(!guildConfs.has(guild.id)) {
+    return console.log(`Attempting to remove ${guild.name} but it's not there.`);
+  }
+
+  fs.unlinkSync(path.resolve(dataDir + path.sep + guild.id + ".json"));
+
+  return true;
+};
+
+exports.has = (guild) => {
+  return guildConfs.has(guild.id);
+};
+
+exports.get = (guild) => {
+  let conf = {};
+  if(guildConfs.has(guild.id)) {
+    let guildConf = guildConfs.get(guild.id);
+    for(let key in guildConf) {
+      if(guildConf[key]) conf[key] = guildConf[key].data;
+      else conf[key] = defaultConf[key].data;
+    }
+  }
+  for(let key in defaultConf) {
+    if(!conf[key]) conf[key] = defaultConf[key].data;
+  }
+  return conf;
+};
+
+exports.addKey = (key, defaultValue) => {
+  let type = defaultValue.constructor.name;
+  if(["TextChannel", "GuildChannel", "Message", "User", "GuildMember", "Guild", "Role", "VoiceChannel", "Emoji", "Invite"].includes(type)) {
+    defaultValue = defaultValue.id;
+  }
+  if(defaultValue.constructor.name !== type && defaultValue.constructor.name !== null) {
+    return false;
+  }
+  defaultConf[key] = {type: defaultValue.constructor.name, data: defaultValue};
+  fs.outputJSONSync(path.resolve(dataDir + path.sep + "default.json"), defaultConf);
+};
+
+exports.setKey = (key, defaultValue) => {
+  if(!(key in defaultConf)) {
+    throw new Error(`:x: The key \`${key}\` does not seem to be present in the default configuration.`);
+  }
+  if(defaultValue.constructor.name !== defaultConf[key].type) {
+    throw new Error(`:x: The key \`${key}\` does not correspond to the type: ${defaultConf[key].type}.`);
+  }
+  defaultConf[key].data = defaultValue;
+  fs.outputJSONSync(path.resolve(dataDir + path.sep + "default.json"), defaultConf);
+};
+
+exports.resetKey = (guild, key) => {
+  if(!guildConfs.has(guild.id)) {
+    throw new Error(`:x: The guild ${guild.id} not found while trying to reset ${key}`);
+  }
+  let thisConf = this.get(guild);
+  if(!(key in thisConf)) {
+    throw new Error(`:x: The key \`${key}\` does not seem to be present in the server configuration.`);
+  }
+  delete thisConf[key];
+  guildConfs.set(guild.id, thisConf);
+  fs.outputJSONSync(path.resolve(dataDir + path.sep + guild.id + ".json"), thisConf);
+};
+
+exports.delKey = (key, delFromAll) => {
+  if(!(key in defaultConf)) {
+    throw new Error(`:x: The key \`${key}\` does not seem to be present in the default configuration.`);
+  }
+  if(["serverID", "serverName", "prefix"].includes(key)) {
+    throw new Error(`:x: The key \`${key}\` is core and cannot be deleted.`);
+  }
+  delete defaultConf[key];
+  if(delFromAll) {
+    guildConfs.forEach(conf => {
+      delete conf[key];
+      fs.outputJSONSync(path.resolve(dataDir + path.sep + conf.guildID + ".json"), conf);
+    });
+  }
+};
+
+exports.hasKey = (key) => {
+  return (key in defaultConf);
+};
+
+exports.set = (guild, key, value) => {
+  let thisConf = {};
+  if(guildConfs.has(guild.id)) {
+    thisConf = guildConfs.get(guild);
+  }
+
+  if(!(key in defaultConf)) {
+    throw new Error(`:x: The key \`${key}\` is not valid according to the Default Configuration.`);
+  }
+
+  if(value.constructor.name !== defaultConf[key].type) {
+    throw new Error(`:x: The key \`${key}\` does not correspond to the type: ${defaultConf[key].type}.`);
+  }
+
+  let type = value.constructor.name;
+  if(["TextChannel", "GuildChannel", "Message", "User", "GuildMember", "Guild", "Role", "VoiceChannel", "Emoji", "Invite"].includes(type)) {
+    value = value.id;
+  }
+
+  thisConf[key] = {data : value , type : defaultConf[key].type};
+  guildConfs.set(guild.id, thisConf);
+  fs.outputJSONSync(path.resolve(dataDir + path.sep + guild.id + ".json"), thisConf);
+  
+  return thisConf;
+};

--- a/functions/loadCommands.js
+++ b/functions/loadCommands.js
@@ -1,4 +1,4 @@
-const fse = require("fs-extra");
+const fs = require("fs-extra");
 const path = require("path");
 
 module.exports = client => {
@@ -19,28 +19,30 @@ const loadCommands = (client, baseDir, counts) => {
 
     let [c, a] = counts;
     try {
-      fse.walk(dir)
-      .on("data", (item) => {
-        let fileinfo = path.parse(item.path),
-          fileDir = fileinfo.dir,
-          name = fileinfo.name,
-          ext = fileinfo.ext;
+      fs.ensureDir(dir, err => {
+        if(err) reject(err);
+        fs.walk(dir)
+        .on("data", (item) => {
+          let fileinfo = path.parse(item.path),
+            fileDir = fileinfo.dir,
+            name = fileinfo.name,
+            ext = fileinfo.ext;
 
-        if(!ext) return;
+          if(!ext || ext !== ".js") return;
 
-        client.funcs.loadSingleCommand(client, name, false, `${fileDir}${path.sep}${fileinfo.base}`).then(cmd => {
-          c++;
-          cmd.conf.aliases.forEach(() => {
-            a++;
+          client.funcs.loadSingleCommand(client, name, false, `${fileDir}${path.sep}${fileinfo.base}`).then(cmd => {
+            c++;
+            cmd.conf.aliases.forEach(() => {
+              a++;
+            });
+          })
+          .catch(e=>{
+            client.funcs.log(e, "Error");
           });
         })
-        .catch(e=>{
-          client.funcs.log(e, "Error");
+        .on("end", () => {
+          resolve([c, a]);
         });
-      })
-      .on("end", () => {
-        //client.funcs.log(`Loaded ${c} commands, with ${a} aliases.`);
-        resolve([c, a]);
       });
     } catch (e) {
       if (e.code === "MODULE_NOT_FOUND") {

--- a/functions/loadDataProviders.js
+++ b/functions/loadDataProviders.js
@@ -42,7 +42,7 @@ const loadDataProviders = (client, baseDir, counts) => {
             let module = /'[^']+'/g.exec(e.toString());
             client.funcs.installNPM(module[0].slice(1,-1))
             .then(() => {
-              client.funcs.loadDatabaseHandlers(client);
+              client.funcs.loadDataProviders(client, baseDir, counts);
             })
             .catch(e => {
               console.error(e);

--- a/functions/loadFunctions.js
+++ b/functions/loadFunctions.js
@@ -1,0 +1,55 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+module.exports = client => {
+  return new Promise( (resolve, reject) => {
+    let counts = [0, 0];
+    loadFunctions(client, client.coreBaseDir, counts).then(counts => {
+      loadFunctions(client, client.clientBaseDir, counts).then(counts => {
+        let [d, o] = counts;
+        client.funcs.log(`Loaded ${d} functions, with ${o} optional.`);
+        resolve();
+      });
+    }).catch(reject);
+  });
+};
+
+const loadFunctions = (client, baseDir, counts) => {
+  return new Promise( (resolve, reject) => {
+    let dir = path.resolve(baseDir + "./functions/");
+    fs.ensureDirSync(dir);
+    fs.readdir(dir, (err, files) => {
+      if (err) reject(err);
+      files = files.filter(f => { return f.slice(-3) === ".js"; });
+      let [d,o] = counts;
+      try {
+        files.forEach(f=> {
+          let file = f.split(".");
+          if(file[0] === "loadFunctions") return;
+          if (file[1] !== "opt") {
+            client.funcs[file[0]] = require(`${dir}/${f}`);
+            d++;
+          } else if (client.config.functions.includes(file[0])) {
+            client.funcs[file[0]] = require(`${dir}/${f}`);
+            o++;
+          }
+        });
+        resolve([d, o]);
+      } catch (e) {
+        if (e.code === "MODULE_NOT_FOUND") {
+          let module = /'[^']+'/g.exec(e.toString());
+          client.funcs.installNPM(module[0].slice(1,-1))
+          .then(() => {
+            client.funcs.loadDatabaseHandlers(client);
+          })
+          .catch(e => {
+            console.error(e);
+            process.exit();
+          });
+        } else {
+          reject(e);
+        }
+      }
+    });
+  });
+};

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -30,7 +30,19 @@ module.exports = function(client, command, reload = false, loadPath = null) {
         category = client.funcs.toTitleCase(cmd.help.category ? cmd.help.category : (pathParts[0] && pathParts[0].length > 0 ? pathParts[0] : "General"));
         subCategory = client.funcs.toTitleCase(cmd.help.subCategory ? cmd.help.subCategory : (pathParts[1] && pathParts[1].length > 0 && !~pathParts[1].indexOf(".") ? pathParts[1] : "General"));
       } catch (e) {
-        reject(`Could not load new command data: ${e.stack}`);
+        if (e.code === "MODULE_NOT_FOUND") {
+          let module = /'[^']+'/g.exec(e.toString());
+          client.funcs.installNPM(module[0].slice(1,-1))
+          .then(() => {
+            client.funcs.loadSingleCommand(client, command, false, loadPath);
+          })
+          .catch(e => {
+            console.error(e);
+            process.exit();
+          });
+        } else {
+          reject(`Could not load new command data: ${e.stack}`);
+        }
       }
     }
 

--- a/inhibitors/disable.js
+++ b/inhibitors/disable.js
@@ -5,7 +5,7 @@ exports.conf = {
 
 exports.run = (client, msg, cmd) => {
   return new Promise((resolve, reject) => {
-    if (cmd.conf.enabled) {
+    if (cmd.conf.enabled && !msg.guildConf.disabledCommands.includes(cmd)) {
       resolve();
     } else {
       reject("This command is currently disabled");

--- a/inhibitors/usage.js
+++ b/inhibitors/usage.js
@@ -5,7 +5,6 @@ exports.conf = {
 
 exports.run = (client, msg, cmd) => {
   return new Promise((resolve, reject) => {
-
     let usage = client.funcs.parseUsage(cmd.help.usage);
     let prefixLength = client.config.prefix.length;
     if (client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length + 1;
@@ -101,7 +100,7 @@ exports.run = (client, msg, cmd) => {
             }
             break;
           case "channel":
-            if (/^<#\d+>$/.test(args[i]) && client.channels.has(args[i])) {
+            if (/^<#\d+>$/.test(args[i]) || client.channels.has(args[i])) {
               args[i] = client.channels.get(/\d+/.exec(args[i])[0]);
               validateArgs(++i);
             } else if (currentUsage.type === "optional" && !repeat) {
@@ -178,7 +177,7 @@ exports.run = (client, msg, cmd) => {
             break;
           case "int":
           case "integer":
-            if (!Number.isInteger(args[i])) {
+            if (!Number.isInteger(parseInt(args[i]))) {
               if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
@@ -355,7 +354,8 @@ exports.run = (client, msg, cmd) => {
               break;
             case "user":
             case "mention":
-              if (client.users.has(/\d+/.exec(args[i])[0]) && args[i].length > 5) {
+              const result = /\d+/.exec(args[i]);
+              if (result && args[i].length > 5 &&  client.users.has(result[0])) {
                 args[i] = client.users.get(/\d+/.exec(args[i])[0]);
                 validated = true;
                 multiPossibles(++p);
@@ -420,7 +420,7 @@ exports.run = (client, msg, cmd) => {
               break;
             case "int":
             case "integer":
-              if (Number.isInteger(args[i])) {
+              if (Number.isInteger(parseInt(args[i]))) {
                 args[i] = parseInt(args[i]);
                 if (currentUsage.possibles[p].min && currentUsage.possibles[p].max) {
                   if (args[i] <= currentUsage.possibles[p].max && args[i] >= currentUsage.possibles[p].min) {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,26 @@
 {
   "name": "komada",
-  "version": "0.5.2",
+  "version": "0.7.0",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "lint": "eslint commands functions inhibitors",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.3",
-    "discord.js": "github:hydrabolt/discord.js#indev",
+    "discord.js": "^10.0.0",
     "fs-extra": "^0.30.0",
-    "moment": "^2.15.1"
+    "moment": "^2.15.1",
+    "moment-duration-format": "^1.3.0"
   },
   "engines": {
-    "node": "6.4.0"
+    "node": ">=6.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.8.1"
   }
 }


### PR DESCRIPTION
- loadFunctions() in a file

Now loading functions from file for efficiency and simplicity
- Command Load fixes
- loadCommands now properly checks for NPM installs
- loadCommands now ensures directory.
- 0.5.3
- 0.5.4
- Remove console logging from help, fix moment dep

Added dependency for moment-duration because it's weird.
Removed logging in help function.
- Whoops on property smh
- 0.5.5
- Fix D.JS Client Options

Changed config.discordOptions to config.clientOptions
- Fixed client-side options

Changed forceFetchUsers to fetchAllMembers as per D.JS Indev
- Fixed Eval Inspection + added regex

Fixed large Evals not being resolved due to inspect being defaulted to infinity.

Sensitive Pattern regex was added to remove sensitive data like tokens, emails and passwords.
- Removed Required Module

Removed 'POS' module as per Evie's request
- Optimised Eval.js

Moved the sensitive pattern function to the clean function
- Moved Sensitive Patterns to Clean Function
- Removed Inspection Limit
- Fixed missing bracket
- Fixed double semi-colon
- Moving a .replace inside a function
- Moved a .replace inside the function
- Fix Int usage
- 0.5.6
- Add ESLint as local dep.
- Fixed a logic error in usage.js
- client comes first.
- SPACING. 2 spaces please.
- client comes first.
- Per. Server. Configs. Biatch.

That's right. OWNED.
- 0.6.0
- Fixed Confs Function

Fixed Confs Function so that it creates the default.json file and initialises it upon first creation.
Changed writeFileSync to outputJSONSync.
Changed readFileSync to readJSONSync.
- Fixed LoadFuncs by adding ensureDirSync
- removed .json property from defaultFile
- Update confs.js
- whoops sowwee
- delKey added
- per-server-config fixes
- Added hasKey
- Added init to commands
- Fixes conf.add() event
- Couple stupid fixes, discord 10.0
- 0.7.0
- temp commit for `conf` command.
- Confs should now be pretty final, should have fixed a few other things
