### PR TITLE
Custom Roles

### DIFF
--- a/commands/System/enable.js
+++ b/commands/System/enable.js
@@ -1,0 +1,30 @@
+exports.run = (client, msg, [commandname]) => {
+  let command;
+  if (client.commands.has(commandname)) {
+    command = commandname;
+  } else if (client.aliases.has(commandname)) {
+    command = client.aliases.get(commandname);
+  }
+  if (!command) {
+    return msg.channel.sendMessage(`I cannot find the command: ${commandname}`);
+  } else {
+    client.commands.get(command).conf.enabled = true;
+    return msg.channel.sendMessage(`Successfully enabled: ${commandname}`);
+  }
+};
+
+exports.conf = {
+  enabled: true,
+  guildOnly: false,
+  aliases: [],
+  permLevel: 4,
+  botPerms: [],
+  requiredFuncs: []
+};
+
+exports.help = {
+  name: "enable",
+  description: "Re-enables or temporarily enables a command. Default state restored on reboot.",
+  usage: "<commandname:str>",
+  usageDelim: ""
+};

--- a/commands/System/reload.js
+++ b/commands/System/reload.js
@@ -43,7 +43,7 @@ exports.run = (client, msg, [commandname]) => {
 exports.conf = {
   enabled: true,
   guildOnly: false,
-  aliases: ["r", "enable", "load"],
+  aliases: ["r", "load"],
   permLevel: 4,
   botPerms: [],
   requiredFuncs: []

--- a/functions/confs.js
+++ b/functions/confs.js
@@ -11,7 +11,9 @@ exports.init = (client) => {
   // Load default configuration, create if not exist.
   defaultConf = {
     prefix: {type: "String", data: client.config.prefix},
-    disabledCommands: {type: "Array", data: "[]"}
+    disabledCommands: {type: "Array", data: []},
+    mod_role: {type: "String", data: "Mods"},
+    admin_role: {type: "String", data: "Devs"}
   };
 
   fs.ensureFileSync(dataDir + path.sep + defaultFile);

--- a/functions/permissionLevel.js
+++ b/functions/permissionLevel.js
@@ -1,13 +1,14 @@
 module.exports = (client, user, guild = null) => {
   return new Promise((resolve, reject) => {
+    let guildConf = client.funcs.confs.get(guild);
     let permlvl = 0;
     if(guild) {
-      try{
+      try {
         let member = guild.member(user);
-        let mod_role = guild.roles.find("name", "Mods");
+        let mod_role = guild.roles.find("name", guildConf.mod_role);
         if (mod_role && member.roles.has(mod_role.id))
           permlvl = 2;
-        let admin_role = guild.roles.find("name", "Devs");
+        let admin_role = guild.roles.find("name", guildConf.admin_role);
         if (admin_role && member.roles.has(admin_role.id))
           permlvl = 3;
         if(member === guild.owner)

--- a/inhibitors/usage.js
+++ b/inhibitors/usage.js
@@ -6,7 +6,7 @@ exports.conf = {
 exports.run = (client, msg, cmd) => {
   return new Promise((resolve, reject) => {
     let usage = client.funcs.parseUsage(cmd.help.usage);
-    let prefixLength = client.config.prefix.length;
+    let prefixLength = msg.guildConf.prefix.length;
     if (client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length + 1;
     let args = msg.content.slice(prefixLength).split(" ").slice(1).join(" ").split(cmd.help.usageDelim !== "" ? cmd.help.usageDelim : null);
     if (args[0] === "") args = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
Added Support for Custom roles in per-server-confs as Strings. I made them both strings so you could easily use the core conf command to change them, as opposed to putting them into an Object. Also changed deletedCommands to be an actual array instead of just a string.
