### PR TITLE
Custom Permission Roles Support

### DIFF
--- a/functions/confs.js
+++ b/functions/confs.js
@@ -11,7 +11,9 @@ exports.init = (client) => {
   // Load default configuration, create if not exist.
   defaultConf = {
     prefix: {type: "String", data: client.config.prefix},
-    disabledCommands: {type: "Array", data: "[]"}
+    disabledCommands: {type: "Array", data: []},
+    mod_role: {type: "String", data: "Mods"},
+    admin_role: {type: "String", data: "Devs"}
   };
 
   fs.ensureFileSync(dataDir + path.sep + defaultFile);
@@ -140,6 +142,7 @@ exports.set = (guild, key, value) => {
   }
 
   thisConf[key] = {data : value , type : defaultConf[key].type};
+
   guildConfs.set(guild.id, thisConf);
   fs.outputJSONSync(path.resolve(dataDir + path.sep + guild.id + ".json"), thisConf);
 

--- a/functions/permissionLevel.js
+++ b/functions/permissionLevel.js
@@ -1,13 +1,14 @@
 module.exports = (client, user, guild = null) => {
   return new Promise((resolve, reject) => {
+    let guildConf = client.funcs.confs.get(guild);
     let permlvl = 0;
     if(guild) {
-      try{
+      try {
         let member = guild.member(user);
-        let mod_role = guild.roles.find("name", "Mods");
+        let mod_role = guild.roles.find("name", guildConf.mod_role);
         if (mod_role && member.roles.has(mod_role.id))
           permlvl = 2;
-        let admin_role = guild.roles.find("name", "Devs");
+        let admin_role = guild.roles.find("name", guildConf.admin_role);
         if (admin_role && member.roles.has(admin_role.id))
           permlvl = 3;
         if(member === guild.owner)


### PR DESCRIPTION
Adds support for custom roles per server.  Also fixes the disabledCommands to be an actual array as opposed to the string "[]". Made the custom roles two different strings so they could easily be edited with the conf core command, instead of dumping them into an object.
