### PR TITLE
Usage Addition/ParseUsage fix

### DIFF
--- a/functions/parseUsage.js
+++ b/functions/parseUsage.js
@@ -10,7 +10,7 @@ const parseTag = (tag, count) => {
   const members = tag.split("|");
 
   members.forEach((e, i) => { // i is the current bound if required for errors.
-    const result = /^([a-z09]+)(?::([a-z09]+)(?:{(?:(\d+(?:\.\d+)?))?(?:,(\d+(?:\.\d+)?))?})?)?$/i.exec(e);
+    const result = /^([a-z0-9]+)(?::([a-z0-9]+)(?:{(?:(\d+(?:\.\d+)?))?(?:,(\d+(?:\.\d+)?))?})?)?$/i.exec(e);
     // I require to modify the regex if we wan't to handle invalid types instead of defaulting them
 
     if (!result)

--- a/inhibitors/usage.js
+++ b/inhibitors/usage.js
@@ -99,6 +99,17 @@ exports.run = (client, msg, cmd) => {
               reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
             }
             break;
+            case "member":
+              if (/^<@!?\d+>$/.test(args[i]) && msg.guild.members.has(/\d+/.exec(args[i])[0]) && args[i].length > 5) {
+                args[i] = msg.guild.members.get(/\d+/.exec(args[i])[0]);
+                validateArgs(++i);
+              } else if (currentUsage.type === "optional" && !repeat) {
+                args.splice(i, 0, undefined);
+                validateArgs(++i);
+              } else {
+                reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
+              }
+              break;
           case "channel":
             if (/^<#\d+>$/.test(args[i]) || client.channels.has(args[i])) {
               args[i] = client.channels.get(/\d+/.exec(args[i])[0]);
@@ -357,6 +368,15 @@ exports.run = (client, msg, cmd) => {
               const result = /\d+/.exec(args[i]);
               if (result && args[i].length > 5 &&  client.users.has(result[0])) {
                 args[i] = client.users.get(/\d+/.exec(args[i])[0]);
+                validated = true;
+                multiPossibles(++p);
+              } else {
+                multiPossibles(++p);
+              }
+              break;
+            case "member":
+              if (result && args[i].length > 5 &&  msg.guild.members.has(result[0])) {
+                args[i] = msg.members.get(/\d+/.exec(args[i])[0]);
                 validated = true;
                 multiPossibles(++p);
               } else {

--- a/inhibitors/usage.js
+++ b/inhibitors/usage.js
@@ -99,17 +99,17 @@ exports.run = (client, msg, cmd) => {
               reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
             }
             break;
-            case "member":
-              if (/^<@!?\d+>$/.test(args[i]) && msg.guild.members.has(/\d+/.exec(args[i])[0]) && args[i].length > 5) {
-                args[i] = msg.guild.members.get(/\d+/.exec(args[i])[0]);
-                validateArgs(++i);
-              } else if (currentUsage.type === "optional" && !repeat) {
-                args.splice(i, 0, undefined);
-                validateArgs(++i);
-              } else {
-                reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
-              }
-              break;
+          case "member":
+            if (/^<@!?\d+>$/.test(args[i]) && msg.guild.members.has(/\d+/.exec(args[i])[0]) && args[i].length > 5) {
+              args[i] = msg.guild.members.get(/\d+/.exec(args[i])[0]);
+              validateArgs(++i);
+            } else if (currentUsage.type === "optional" && !repeat) {
+              args.splice(i, 0, undefined);
+              validateArgs(++i);
+            } else {
+              reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
+            }
+            break;
           case "channel":
             if (/^<#\d+>$/.test(args[i]) || client.channels.has(args[i])) {
               args[i] = client.channels.get(/\d+/.exec(args[i])[0]);
@@ -376,7 +376,7 @@ exports.run = (client, msg, cmd) => {
               break;
             case "member":
               if (result && args[i].length > 5 &&  msg.guild.members.has(result[0])) {
-                args[i] = msg.members.get(/\d+/.exec(args[i])[0]);
+                args[i] = msg.guild.members.get(/\d+/.exec(args[i])[0]);
                 validated = true;
                 multiPossibles(++p);
               } else {


### PR DESCRIPTION
Added Member as a valid usage type (so you don't have to do msg.guild.member(user object), not that it's that hard to do in the first place.)
Also fixed RegEx for ParseUsage to accept all numbers now instead of just the numbers 0 and 9

Screenshot of error when a usage has a number that isn't 0 or 9 in it
https://gyazo.com/2229ba64e675a48c8ae47e08d5ddf67a
