### PR TITLE
Download.js VM "Cannot Find Module" Fix

### DIFF
--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -1,6 +1,8 @@
 const request = require("superagent");
 const vm = require("vm");
+const exec = require("child_process").exec;
 var fs = require("fs-extra");
+
 
 exports.run = (client, msg, [url, folder = "Downloaded"]) => {
   request.get(url, (err, res) => {
@@ -10,20 +12,51 @@ exports.run = (client, msg, [url, folder = "Downloaded"]) => {
     var mod = {
       exports: {}
     };
+
+    let code =
+    `(function(require) {
+      ${res.text};
+    })`;
+
     try {
-      vm.runInNewContext(res.text, { module: mod, exports: mod.exports }, {timeout: 500});
+      vm.runInNewContext(code, { module: mod, exports: mod.exports}, {timeout: 500})(require);
     } catch (e) {
+      if (e.message.startsWith("Cannot find module ")) {
+        msg.channel.sendMessage("Couldn't find module... Attempting to download.").then(m => {
+        let moduleName = e.message.substring(19).replace(/'/g, "");
+        client.funcs.installNPM(moduleName).then((resolved) => {
+          m.edit(`Downloaded **${moduleName}!** I will make an attempt to load the command now.`);
+          if (client.tempmodules === undefined) client.tempmodules = [];
+          client.tempmodules.push(moduleName)
+          client.commands.get('download').run(client, msg, [url, folder]);
+        }).catch(e => {
+          console.log(e);
+        })
+        return;
+      });
+      } else if (e.message.startsWith("ENOENT: no such file or directory, open ")) {
+        msg.channel.sendMessage("Couldn't find module... Attempting to download.");
+        let string = e.message.substring(e.message.indexOf("node_modules"), e.message.lastIndexOf("\\"));
+        let moduleName = string.substring(string.indexOf("\\")+1, string.length);
+        client.funcs.installNPM(moduleName).then((resolved) => {
+          m.edit(`Downloaded **${moduleName}!** I will make an attempt to load the command now.`)
+          if (client.tempmodules === undefined) client.tempmodules = [];
+          client.tempmodules.push(moduleName);
+          client.commands.get('download').run(client, msg, [url, folder]);
+        }).catch(e => {
+          console.log(e);
+        })
+        return;
+      } else {
       msg.reply(`URL command not valid: ${e}`);
       return;
     }
+    return;
+  }
 
     let name = mod.exports.help.name;
     let description = mod.exports.help.description;
 
-    if (mod.exports.conf.selfbot && client.config.selfbot) {
-      msg.reply(`The command \`${name}\` is only usable in selfbots!`);
-      return;
-    }
     if (client.commands.has(name)) {
       msg.reply(`The command \`${name}\` already exists in the bot!`);
       return;
@@ -48,8 +81,31 @@ ${description}
     });
 
     collector.on("end", (collected, reason) => {
-      if (reason === "time") return msg.channel.sendMessage(":timer: 5s timeout. Can you read a bit faster?");
-      if (reason === "aborted") return msg.channel.sendMessage(":no_mobile_phones: Load Aborted. Command not installed.");
+      if (reason === "aborted" || reason === "time") {
+        if (client.tempmodules !== undefined) {
+        msg.channel.sendMessage(":no_mobile_phones: Load Aborted. Command not installed. Lemme remove those useless modules for you :smile:").then(m => {
+          exec(`npm uninstall ${client.tempmodules.join(' ')}`, (e, stdout, stderr) => {
+            if (e) {
+              msg.channel.sendMessage(`Failed uninstalling the modules.. Sorry about that.`);
+              console.log(e);
+              return;
+            } else {
+              console.log(stdout);
+              console.log(stderr);
+              m.edit(`Succesfully uninstalled : **${client.tempmodules.join(', ')}**`);
+              client.tempmodules.forEach(module => {
+                delete require.cache[require.resolve(module)];
+              });
+              delete client.tempmodules;
+              return;
+            }
+        });
+      });
+      } else {
+        msg.channel.sendMessage(":no_mobile_phones: Load Aborted. Command not installed.");
+        return;
+      }
+    }
       if (reason === "success") {
         msg.channel.sendMessage(":inbox_tray: `Loading Command...`").then(m => {
           let category = mod.exports.help.category ? mod.exports.help.category : client.funcs.toTitleCase(folder);
@@ -63,10 +119,12 @@ ${description}
               client.funcs.loadSingleCommand(client, name, false, `${dir}/${name}.js`)
                 .then((cmd) => {
                   m.edit(`:inbox_tray: Successfully Loaded: ${cmd.help.name}`);
+                  delete client.tempmodules;
                 })
                 .catch(e => {
                   m.edit(`:no_mobile_phones: Command load failed: ${name}\n\`\`\`${e.stack}\`\`\``);
                   fs.unlink(`${dir}/${name}.js`);
+                  delete client.tempmodules;
                 });
             });
           });

--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -62,6 +62,11 @@ exports.run = (client, msg, [url, folder = "Downloaded"]) => {
       return;
     }
 
+    if (mod.exports.conf.selfbot && !client.config.selfbot) {
+      msg.reply(`The command \`${name}\` is only usable in selfbots!`);
+      return;
+    }
+
     msg.channel.sendMessage(`Are you sure you want to load the following command into your bot?
 \`\`\`asciidoc
 === NAME ===

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -25,7 +25,7 @@ module.exports = function(client, command, reload = false, loadPath = null) {
     } else {
       try {
         cmd = require(loadPath);
-        if (cmd.conf.selfbot && client.config.selfbot) {
+        if (cmd.conf.selfbot && !client.config.selfbot) {
           return reject(`The command \`${cmd.help.name}\` is only usable in selfbots!`);
         }
         let pathParts = loadPath.split(path.sep);


### PR DESCRIPTION
Working Download.js Fix that automatically downlaods NPM Modules if the VM cannot load without them. If the VM cannot find the modules, all of the modules will be installed 1 by 1 until it can finally load and put into `client.tempmodules` (which is deleted later). If you choose to abort the command or time runs out, all of the modules will be safely uninstalled so you don't have a lot of useless modules still sitting on your system.
Do test and make sure it works for you or throw me any errors you find.