### PR TITLE
Monitors addition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
     "guard-for-in": "warn",
     "consistent-return": ["warn", { "treatUndefinedAsUnspecified": true }],
     "no-use-before-define": ["warn", { "functions": true, "classes": true }],
-    "no-eval": "warn"
+    "no-eval": "warn",
+    "max-len": "off"
   }
 }

--- a/app.js
+++ b/app.js
@@ -44,7 +44,7 @@ exports.start = (config) => {
   });
 
   client.on("message", (msg) => {
-    if (msg.user === client.user) return;
+    if (msg.author.bot) return;
     const conf = client.funcs.confs.get(msg.guild);
     msg.guildConf = conf;
     client.funcs.runCommandMonitors(client, msg).catch(reason => msg.channel.sendMessage(reason).catch(console.error));
@@ -78,8 +78,8 @@ exports.start = (config) => {
     })
     .catch((reason) => {
       if (reason) {
-        console.log(reason.stack);
-        msg.channel.sendMessage(reason).catch(console.error);
+        client.funcs.log(reason.stack, 'error');
+        msg.channel.sendCode(reason).catch(console.error);
       }
     });
   });

--- a/functions/loadCommandMonitors.js
+++ b/functions/loadCommandMonitors.js
@@ -1,0 +1,58 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+module.exports = (client) => {
+  client.commandMonitors.clear();
+  const counts = [0, 0];
+  loadCommandMonitors(client, client.coreBaseDir, counts).then((counts) => {
+    loadCommandMonitors(client, client.clientBaseDir, counts).then((counts) => {
+      const [p, o] = counts;
+      client.funcs.log(`Loaded ${p} command monitors, with ${o} optional.`);
+    });
+  });
+};
+
+const loadCommandMonitors = (client, baseDir, counts) => {
+  return new Promise((resolve, reject) => {
+    const dir = path.resolve(`${baseDir}./monitors/`);
+    fs.ensureDir(dir, (err) => {
+      if (err) console.error(err);
+      fs.readdir(dir, (err, files) => {
+        if (err) console.error(err);
+        let [p, o] = counts;
+        try {
+          files = files.filter((f) => { return f.slice(-3) === ".js"; });
+          files.forEach((f) => {
+            const file = f.split(".");
+            let props;
+            if (file[1] !== "opt") {
+              props = require(`${dir}/${f}`);
+              client.commandMonitors.set(file[0], props);
+              p++;
+            } else if (client.config.commandMonitors.includes(file[0])) {
+              props = require(`${dir}/${f}`);
+              client.commandMonitors.set(file[0], props);
+              o++;
+            }
+          });
+        } catch (e) {
+          if (e.code === "MODULE_NOT_FOUND") {
+            const module = /'[^']+'/g.exec(e.toString());
+            client.funcs.installNPM(module[0].slice(1, -1))
+              .then(() => {
+                client.funcs.loadCommandMonitors(client);
+              })
+              .catch((e) => {
+                console.error(e);
+                process.exit();
+              });
+          } else {
+            console.error(e);
+          }
+          reject();
+        }
+        resolve([p, o]);
+      });
+    });
+  });
+};

--- a/functions/runCommandMonitors.js
+++ b/functions/runCommandMonitors.js
@@ -1,0 +1,16 @@
+module.exports = (client, msg) => {
+  return new Promise((resolve, reject) => {
+    const mps = [true];
+    client.commandMonitors.forEach((mProc) => {
+      if (mProc.conf.enabled) {
+        mps.push(mProc.run(client, msg));
+      }
+    });
+    Promise.all(mps)
+      .then((value) => {
+        resolve(value);
+      }, (reason) => {
+        reject(reason);
+      });
+  });
+};

--- a/monitors/profanity.js
+++ b/monitors/profanity.js
@@ -1,0 +1,19 @@
+const profanityFinder = require("profanity-finder");
+
+const findProfanity = profanityFinder.findprofanity;
+
+exports.conf = {
+  enabled: false,
+};
+
+exports.run = (client, msg) => {
+  return new Promise((resolve, reject) => {
+    const bool = findProfanity(msg.content);
+    if (bool) {
+      msg.delete();
+      reject("You're not allowed to use profanity in your messages!");
+    } else {
+      resolve();
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.9.0",
+  "version": "0.8.10",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
The Hall Monitors have arrived. :smile:
Adds:

- loadCommandMonitors (loads monitors)
- runCommandMonitors (runs monitors if they're enabled)
- profanity.js (First Monitor, disabled by default to prevent issues)

Modifies:
- App.js (Now Runs monitors before the checking of the command && ignores its own messages to prevent an infinite loop... might be useful if we prevent all bots messages.. //givemesuggestions) 