### PR TITLE
Better Support for Arrays/Ints/Booleans/Strings

### DIFF
--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -11,14 +11,20 @@ exports.run = (client, msg, [action, key, ...value]) => {
   } else
 
   if (action === "set") {
-    if (!key || value === undefined) return msg.reply("Please provide both a key and value!");
-    if (msg.guildConf[key].constructor.name === "String") {
-      value = value.join(" ");
-    } else
-    if (msg.guildConf[key].constructor.name === "Boolean") {
-      value = value[0];
+    if (!key || value[0] === undefined) return msg.reply("Please provide both a key and value!");
+    const type = value[0].constructor.name;
+    if (["TextChannel", "GuildChannel", "Message", "User", "GuildMember", "Guild", "Role", "VoiceChannel", "Emoji", "Invite"].includes(type)) {
+      value = value[0].id;
+    } else {
+      value = value.join(" ").toString();
     }
     client.funcs.confs.set(msg.guild, key, value);
+    if (msg.guildConf[key].constructor.name === "Array") {
+      if (msg.guildConf[key].includes(value)) {
+        return msg.reply(`The value ${value} for ${key} has been added.`);
+      }
+      return msg.reply(`The value ${value} for ${key} has been removed.`);
+    }
     return msg.reply(`The value for ${key} has been set to: ${value}`);
   } else
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
Edited Core Configuration functions to better allow for **different** types of data.
Edited Conf.js command to use the new updates.
Most of these changes skew in the direction of using strings for everything, and letting the Configuration functions do all the changing to the correct types for you.

Differences:
`client.funcs.confs.set(msg.guild, 'booleanKey', true)` => `client.funcs.confs.set(msg.guild, 'booleanKey', 'true')`
`client.funcs.confs.set(msg.guild, 'arrayKey', ['item1', 'item2'])` => `client.funcs.confs.set(msg.guild, 'arrayKey', 'item1')` (will add or delete item1 if it's in there or not, respectively)

**Note**: The only functions that were changed that are breaking are setKey() and set(). If you use either of these for any of these types (booleans, arrays, ints), you will most definitely have to edit them accordingly.