### PR TITLE
Reload all the things!

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const Discord = require("discord.js");
 const chalk = require("chalk");
+const loadFunctions = require("./functions/loadFunctions.js");
 
 const clk = new chalk.constructor({ enabled: true });
 
@@ -22,7 +23,7 @@ exports.start = (config) => {
   client.clientBaseDir = `${process.cwd()}/`;
 
   // Load core functions, then everything else
-  require("./functions/loadFunctions.js")(client).then(() => {
+  loadFunctions(client).then(() => {
     client.funcs.loadDataProviders(client);
     client.funcs.loadCommands(client);
     client.funcs.loadCommandInhibitors(client);
@@ -78,8 +79,8 @@ exports.start = (config) => {
     })
     .catch((reason) => {
       if (reason) {
-        client.funcs.log(reason.stack, 'error');
-        msg.channel.sendCode(reason).catch(console.error);
+        if (reason.stack) client.funcs.log(reason.stack, "error");
+        msg.channel.sendCode("", reason).catch(console.error);
       }
     });
   });

--- a/commands/System/reload.js
+++ b/commands/System/reload.js
@@ -1,9 +1,9 @@
 exports.run = (client, msg, [type, name]) => {
-  switch (type) { // eslint-disable-line default-case
+  switch (type) {
     case "function":
       msg.channel.sendMessage(`Attemping to reload function ${name}`).then((m) => {
         client.funcs.reload.function(client, msg, client.clientBaseDir, name).then(() => {
-          m.edit(`:white_check_mark: Succesfully reloaded local function ${name}`);
+          m.edit(`:white_check_mark: Succesfully reloaded function ${name}`);
         }).catch((e) => {
           m.edit(e);
         });
@@ -12,7 +12,7 @@ exports.run = (client, msg, [type, name]) => {
     case "inhibitor":
       msg.channel.sendMessage(`Attempting to reload inhibitor ${name}`).then((m) => {
         client.funcs.reload.inhibitor(client, msg, client.clientBaseDir, name).then(() => {
-          m.edit(`:white_check_mark: Succesfully reloaded local inhibitor ${name}`);
+          m.edit(`:white_check_mark: Succesfully reloaded inhibitor ${name}`);
         }).catch((e) => {
           m.edit(e);
         });
@@ -21,7 +21,7 @@ exports.run = (client, msg, [type, name]) => {
     case "monitor":
       msg.channel.sendMessage(`Attempting to reload monitor ${name}`).then((m) => {
         client.funcs.reload.monitor(client, msg, client.clientBaseDir, name).then(() => {
-          m.edit(`:white_check_mark: Succesfully reloaded local monitor ${name}`);
+          m.edit(`:white_check_mark: Succesfully reloaded monitor ${name}`);
         }).catch((e) => {
           m.edit(e);
         });
@@ -30,16 +30,16 @@ exports.run = (client, msg, [type, name]) => {
     case "provider":
       msg.channel.sendMessage(`Attempting to reload provider ${name}`).then((m) => {
         client.funcs.reload.provider(client, msg, client.clientBaseDir, name).then(() => {
-          m.edit(`:white_check_mark: Succesfully reloaded local provider ${name}`);
+          m.edit(`:white_check_mark: Succesfully reloaded provider ${name}`);
         }).catch((e) => {
           m.edit(e);
         });
       });
       break;
     case "event":
-      msg.channel.sendMessage(`Attempting to reload provider ${name}`).then((m) => {
+      msg.channel.sendMessage(`Attempting to reload event ${name}`).then((m) => {
         client.funcs.reload.event(client, msg, name).then(() => {
-          m.edit(`:white_check_mark: Succesfully reloaded local event ${name}`);
+          m.edit(`:white_check_mark: Succesfully reloaded event ${name}`);
         }).catch((e) => {
           m.edit(e);
         });
@@ -54,7 +54,7 @@ exports.run = (client, msg, [type, name]) => {
         default:
           msg.channel.sendMessage(`Attempting to reload command ${name}`).then((m) => {
             client.funcs.reload.command(client, msg, client.clientBaseDir, name).then(() => {
-              m.edit(`:white_check_mark: Succesfully reloaded local command ${name}`);
+              m.edit(`:white_check_mark: Succesfully reloaded command ${name}`);
             }).catch((e) => {
               m.edit(e);
             });

--- a/commands/System/reload.js
+++ b/commands/System/reload.js
@@ -1,44 +1,67 @@
-const path = require("path");
-
-exports.run = (client, msg, [commandname]) => {
-  if (commandname === "all") {
-    client.funcs.log("Reloading all commands");
-    client.funcs.loadCommands(client);
-    return;
-  }
-  let command;
-  if (client.commands.has(commandname)) {
-    command = commandname;
-  } else if (client.aliases.has(commandname)) {
-    command = client.aliases.get(commandname);
-  }
-  if (!command) {
-    client.funcs.getFileListing(client, client.coreBaseDir, "commands")
-      .then((files) => {
-        const newCommands = files.filter(f => f.name === command);
-        newCommands.forEach((file) => {
-          msg.channel.sendMessage(`Loading New Command: ${commandname}`)
-            .then((m) => {
-              client.funcs.loadSingleCommand(client, command, false, `${file.path}${path.sep}${file.base}`).then((cmd) => {
-                m.edit(`Successfully Loaded: ${cmd.help.name}`);
-              })
-                .catch((e) => {
-                  m.edit(`Command load failed for ${command}: \n\`\`\`${e.stack}\`\`\``);
-                });
-            });
+exports.run = (client, msg, [type, name]) => {
+  switch (type) { // eslint-disable-line default-case
+    case "function":
+      msg.channel.sendMessage(`Attemping to reload function ${name}`).then((m) => {
+        client.funcs.reload.function(client, msg, client.clientBaseDir, name).then(() => {
+          m.edit(`:white_check_mark: Succesfully reloaded local function ${name}`);
+        }).catch((e) => {
+          m.edit(e);
         });
       });
-  } else {
-    msg.channel.sendMessage(`Reloading: ${command}`)
-      .then((m) => {
-        client.funcs.loadSingleCommand(client, command, true)
-          .then((cmd) => {
-            m.edit(`Successfully reloaded: ${cmd.help.name}`);
-          })
-          .catch((e) => {
-            m.edit(`Command reload failed for ${command}: \n\`\`\`${e}\`\`\``);
-          });
+      break;
+    case "inhibitor":
+      msg.channel.sendMessage(`Attempting to reload inhibitor ${name}`).then((m) => {
+        client.funcs.reload.inhibitor(client, msg, client.clientBaseDir, name).then(() => {
+          m.edit(`:white_check_mark: Succesfully reloaded local inhibitor ${name}`);
+        }).catch((e) => {
+          m.edit(e);
+        });
       });
+      break;
+    case "monitor":
+      msg.channel.sendMessage(`Attempting to reload monitor ${name}`).then((m) => {
+        client.funcs.reload.monitor(client, msg, client.clientBaseDir, name).then(() => {
+          m.edit(`:white_check_mark: Succesfully reloaded local monitor ${name}`);
+        }).catch((e) => {
+          m.edit(e);
+        });
+      });
+      break;
+    case "provider":
+      msg.channel.sendMessage(`Attempting to reload provider ${name}`).then((m) => {
+        client.funcs.reload.provider(client, msg, client.clientBaseDir, name).then(() => {
+          m.edit(`:white_check_mark: Succesfully reloaded local provider ${name}`);
+        }).catch((e) => {
+          m.edit(e);
+        });
+      });
+      break;
+    case "event":
+      msg.channel.sendMessage(`Attempting to reload provider ${name}`).then((m) => {
+        client.funcs.reload.event(client, msg, name).then(() => {
+          m.edit(`:white_check_mark: Succesfully reloaded local event ${name}`);
+        }).catch((e) => {
+          m.edit(e);
+        });
+      });
+      break;
+    case "command":
+      switch (name) {
+        case "all":
+          client.funcs.loadCommands(client);
+          msg.channel.sendMessage(":white_check_mark: Reloaded all commands.");
+          break;
+        default:
+          msg.channel.sendMessage(`Attempting to reload command ${name}`).then((m) => {
+            client.funcs.reload.command(client, msg, client.clientBaseDir, name).then(() => {
+              m.edit(`:white_check_mark: Succesfully reloaded local command ${name}`);
+            }).catch((e) => {
+              m.edit(e);
+            });
+          });
+          break;
+      }
+      break;
   }
 };
 
@@ -54,5 +77,6 @@ exports.conf = {
 exports.help = {
   name: "reload",
   description: "Reloads the command file, if it's been updated or modified.",
-  usage: "<all:literal|commandname:str>",
+  usage: "<function|inhibitor|monitor|provider|event|command> <name:str>",
+  usageDelim: " ",
 };

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -1,0 +1,158 @@
+const path = require("path");
+
+exports.function = (client, msg, dir, funcName) => new Promise((resolve, reject) => {
+  if (client.funcs.hasOwnProperty(funcName)) {
+    client.funcs[funcName] = "";
+    client.funcs.getFileListing(client, dir, "functions").then((files) => {
+      const oldFunction = files.filter(f => f.name === funcName);
+      try {
+        oldFunction.forEach((file) => {
+          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+          client.funcs[funcName] = require(`${file.path}${path.sep}${file.base}`);
+          if (client.funcs[funcName].init) {
+            client.funcs[funcName].init(client);
+          }
+        });
+      } catch (error) {
+        reject(`:x: ${error}`);
+        return;
+      }
+      resolve();
+    });
+  } else {
+    reject(`:x: The function **${funcName}** does not seem to exist!`);
+  }
+});
+
+exports.inhibitor = (client, msg, dir, inhibName) => new Promise((resolve, reject) => {
+  if (client.commandInhibitors.has(inhibName)) {
+    client.commandInhibitors.delete(inhibName);
+    client.funcs.getFileListing(client, dir, "inhibitors").then((files) => {
+      const oldInhibitor = files.filter(f => f.name === inhibName);
+      try {
+        oldInhibitor.forEach((file) => {
+          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+          const props = require(`${file.path}${path.sep}${file.base}`);
+          client.commandInhibitors.set(file.name, props);
+          if (props.init) {
+            props.init(client);
+          }
+        });
+      } catch (error) {
+        reject(`:x: ${error}`);
+        return;
+      }
+      resolve();
+    });
+  } else {
+    reject(`:x: The inhibitor **${inhibName} does not seem to exist!`);
+  }
+});
+
+exports.monitor = (client, msg, dir, monitName) => new Promise((resolve, reject) => {
+  if (client.commandMonitors.has(monitName)) {
+    client.commandMonitors.delete(monitName);
+    client.funcs.getFileListing(client, dir, "monitors").then((files) => {
+      const oldMonitor = files.filter(f => f.name === monitName);
+      try {
+        oldMonitor.forEach((file) => {
+          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+          const props = require(`${file.path}${path.sep}${file.base}`);
+          client.commandMonitors.set(file.name, props);
+          if (props.init) {
+            props.init(client);
+          }
+        });
+      } catch (error) {
+        reject(`:x: ${error}`);
+        return;
+      }
+      resolve();
+    });
+  } else {
+    reject(`:x: The monitor **${monitName} does not seem to exist!`);
+  }
+});
+
+exports.provider = (client, msg, dir, providerName) => new Promise((resolve, reject) => {
+  if (client.dataProviders.has(providerName)) {
+    client.dataProviders.delete(providerName);
+    client.funcs.getFileListing(client, dir, "dataProviders").then((files) => {
+      const oldProvider = files.filter(f => f.name === providerName);
+      try {
+        oldProvider.forEach((file) => {
+          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+          const props = require(`${file.path}${path.sep}${file.base}`);
+          client.dataProviders.set(file.name, props);
+          if (props.init) {
+            props.init(client);
+          }
+        });
+      } catch (error) {
+        reject(`:x: ${error}`);
+        return;
+      }
+      resolve();
+    });
+  } else {
+    reject(`:x: The provider **${providerName} does not seem to exist!`);
+  }
+});
+
+exports.event = (client, msg, eventName) => new Promise((resolve, reject) => {
+  client.funcs.getFileListing(client, client.clientBaseDir, "events").then((files) => {
+    const oldEvent = files.filter(f => f.name === eventName);
+    if (oldEvent[0] && oldEvent[0].name === eventName) {
+      let listener;
+      if (client._events[eventName].length !== 0) {
+        listener = client._events[eventName].filter((ev) => { return ev === require.resolve(`${oldEvent[0].path}${path.sep}${oldEvent[0].base}`); });
+        console.log(listener);
+      } else {
+        listener = client._events[eventName];
+      }
+      client.removeListener(eventName, listener);
+      try {
+        oldEvent.forEach((file) => {
+          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+          client.on(file.name, (...args) => require(`${file.path}${path.sep}${file.base}`).run(client, ...args));
+        });
+      } catch (error) {
+        reject(`:x: ${error}`);
+        return;
+      }
+      resolve();
+    } else {
+      reject(`:x: The event **${eventName}** does not seem to exist!`);
+    }
+  });
+});
+
+exports.command = (client, msg, commandName) => new Promise((resolve, reject) => {
+  let command;
+  if (client.commands.has(commandName)) {
+    command = commandName;
+  } else if (client.aliases.has(commandName)) {
+    command = client.aliases.get(commandName);
+  }
+  if (!command) {
+    client.funcs.getFileListing(client, client.coreBaseDir, "commands")
+      .then((files) => {
+        const newCommands = files.filter(f => f.name === command);
+        newCommands.forEach((file) => {
+          client.funcs.loadSingleCommand(client, command, false, `${file.path}${path.sep}${file.base}`)
+                .catch((e) => {
+                  reject(`:x: ${e}`);
+                });
+        });
+      });
+    resolve();
+  } else {
+    client.funcs.loadSingleCommand(client, command, true)
+          .then(() => {
+            resolve();
+          })
+          .catch((e) => {
+            reject(`:x: ${e}`);
+          });
+  }
+});

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -2,22 +2,26 @@ const path = require("path");
 
 exports.function = (client, msg, dir, funcName) => new Promise((resolve, reject) => {
   if (client.funcs.hasOwnProperty(funcName)) {
-    client.funcs[funcName] = "";
     client.funcs.getFileListing(client, dir, "functions").then((files) => {
       const oldFunction = files.filter(f => f.name === funcName);
-      try {
-        oldFunction.forEach((file) => {
-          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
-          client.funcs[funcName] = require(`${file.path}${path.sep}${file.base}`);
-          if (client.funcs[funcName].init) {
-            client.funcs[funcName].init(client);
-          }
-        });
-      } catch (error) {
-        reject(`:x: ${error}`);
-        return;
+      if (oldFunction[0]) {
+        client.funcs[funcName] = "";
+        try {
+          oldFunction.forEach((file) => {
+            delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+            client.funcs[funcName] = require(`${file.path}${path.sep}${file.base}`);
+            if (client.funcs[funcName].init) {
+              client.funcs[funcName].init(client);
+            }
+          });
+        } catch (error) {
+          reject(`:x: ${error}`);
+          return;
+        }
+        resolve();
+      } else {
+        reject(`:x: The function **${funcName}** does not reside in ${dir}functions`);
       }
-      resolve();
     });
   } else {
     reject(`:x: The function **${funcName}** does not seem to exist!`);
@@ -26,76 +30,88 @@ exports.function = (client, msg, dir, funcName) => new Promise((resolve, reject)
 
 exports.inhibitor = (client, msg, dir, inhibName) => new Promise((resolve, reject) => {
   if (client.commandInhibitors.has(inhibName)) {
-    client.commandInhibitors.delete(inhibName);
     client.funcs.getFileListing(client, dir, "inhibitors").then((files) => {
       const oldInhibitor = files.filter(f => f.name === inhibName);
-      try {
-        oldInhibitor.forEach((file) => {
-          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
-          const props = require(`${file.path}${path.sep}${file.base}`);
-          client.commandInhibitors.set(file.name, props);
-          if (props.init) {
-            props.init(client);
-          }
-        });
-      } catch (error) {
-        reject(`:x: ${error}`);
-        return;
+      if (oldInhibitor[0]) {
+        try {
+          oldInhibitor.forEach((file) => {
+            client.commandInhibitors.delete(file.name);
+            delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+            const props = require(`${file.path}${path.sep}${file.base}`);
+            client.commandInhibitors.set(file.name, props);
+            if (props.init) {
+              props.init(client);
+            }
+          });
+        } catch (error) {
+          reject(`:x: ${error}`);
+          return;
+        }
+        resolve();
+      } else {
+        reject(`:x: The inhibitor **${inhibName}** does not seem to reside in ${dir}inhibitors`);
       }
-      resolve();
     });
   } else {
-    reject(`:x: The inhibitor **${inhibName} does not seem to exist!`);
+    reject(`:x: The inhibitor **${inhibName}** does not seem to exist!`);
   }
 });
 
 exports.monitor = (client, msg, dir, monitName) => new Promise((resolve, reject) => {
   if (client.commandMonitors.has(monitName)) {
-    client.commandMonitors.delete(monitName);
     client.funcs.getFileListing(client, dir, "monitors").then((files) => {
       const oldMonitor = files.filter(f => f.name === monitName);
-      try {
-        oldMonitor.forEach((file) => {
-          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
-          const props = require(`${file.path}${path.sep}${file.base}`);
-          client.commandMonitors.set(file.name, props);
-          if (props.init) {
-            props.init(client);
-          }
-        });
-      } catch (error) {
-        reject(`:x: ${error}`);
-        return;
+      if (oldMonitor[0]) {
+        try {
+          oldMonitor.forEach((file) => {
+            client.commandMonitors.delete(file.name);
+            delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+            const props = require(`${file.path}${path.sep}${file.base}`);
+            client.commandMonitors.set(file.name, props);
+            if (props.init) {
+              props.init(client);
+            }
+          });
+        } catch (error) {
+          reject(`:x: ${error}`);
+          return;
+        }
+        resolve();
+      } else {
+        reject(`:x: The monitor **${monitName}** does not reside in ${dir}monitors`);
       }
-      resolve();
     });
   } else {
-    reject(`:x: The monitor **${monitName} does not seem to exist!`);
+    reject(`:x: The monitor **${monitName}** does not seem to exist!`);
   }
 });
 
 exports.provider = (client, msg, dir, providerName) => new Promise((resolve, reject) => {
   if (client.dataProviders.has(providerName)) {
-    client.dataProviders.delete(providerName);
     client.funcs.getFileListing(client, dir, "dataProviders").then((files) => {
       const oldProvider = files.filter(f => f.name === providerName);
-      try {
-        oldProvider.forEach((file) => {
-          delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
-          const props = require(`${file.path}${path.sep}${file.base}`);
-          client.dataProviders.set(file.name, props);
-          if (props.init) {
-            props.init(client);
-          }
-        });
-      } catch (error) {
-        reject(`:x: ${error}`);
-        return;
+      if (oldProvider[0]) {
+        try {
+          oldProvider.forEach((file) => {
+            client.dataProviders.delete(file.name);
+            delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
+            const props = require(`${file.path}${path.sep}${file.base}`);
+            client.dataProviders.set(file.name, props);
+            if (props.init) {
+              props.init(client);
+            }
+          });
+        } catch (error) {
+          reject(`:x: ${error}`);
+          return;
+        }
+        resolve();
+      } else {
+        reject(`:x: The provider **${providerName}** does not seem to reside in ${dir}dataProviders`);
       }
-      resolve();
     });
   } else {
-    reject(`:x: The provider **${providerName} does not seem to exist!`);
+    reject(`:x: The provider **${providerName}** does not seem to exist!`);
   }
 });
 
@@ -105,8 +121,7 @@ exports.event = (client, msg, eventName) => new Promise((resolve, reject) => {
     if (oldEvent[0] && oldEvent[0].name === eventName) {
       let listener;
       if (client._events[eventName].length !== 0) {
-        listener = client._events[eventName].filter((ev) => { return ev === require.resolve(`${oldEvent[0].path}${path.sep}${oldEvent[0].base}`); });
-        console.log(listener);
+        listener = client._events[eventName][1];
       } else {
         listener = client._events[eventName];
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
Introduces new reloading features to be able to reload all pieces of Komada.
Reload command can now properly reload pieces, but only those in your own local bots directory, unless its a command, which will reload regardless of directory.
Now able to reload:
- Events
- Functions
- Database Providers
- Monitors
- Inhibitors

Additions:
client.funcs.reload.function(client, msg, dir, funcName)
client.funcs.reload.inhibitor(client, msg, dir, inhibName)
client.funcs.reload.monitor(client, msg, dir, monitName)
client.funcs.reload.provider(client, msg, dir, providerName)
client.funcs.reload.event(client, msg, eventName) -- Only Local Events are allowed to be reloaded.