### PR TITLE
Proposing client.methods.<MethodName>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- client.methods.<MethodName>
+
 ### Changed
+- messageMonitors renamed to messageMonitors
 - Help no longer placing un-catergorised commands in its own "catergory"
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- client.methods.<MethodName>
+- client.methods.MethodName
 
 ### Changed
 - commandMonitors renamed to messageMonitors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - client.methods.<MethodName>
 
 ### Changed
-- messageMonitors renamed to messageMonitors
+- commandMonitors renamed to messageMonitors
 - Help no longer placing un-catergorised commands in its own "catergory"
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ export them to any other piece that we may need them in. For example, if your bo
 a larger bot and you need to make use of the shardingManager, but can't do since
 it's a native Discord.js function, well now you can.
 
+Current Methods are:
+Collections => `client.methods.collection`
+Rich Embed Builder => `client.methods.embed`
+Message Collector => `client.methods.messageCollector`
+ShardingManager => `client.methods.shard`
+WebhookClient => `client.methods.webhook`
+
 To use any of the methods, you follow this same structure:
 ```js
 let method = new client.methods.<MethodName>(OptionalMethodProperties);

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ a larger bot and you need to make use of the shardingManager, but can't do since
 it's a native Discord.js function, well now you can.
 
 Current Methods are:
-Collections => `client.methods.collection`
-Rich Embed Builder => `client.methods.embed`
-Message Collector => `client.methods.messageCollector`
-ShardingManager => `client.methods.shard`
-WebhookClient => `client.methods.webhook`
+Collections => `client.methods.Collection`
+Rich Embed Builder => `client.methods.Embed`
+Message Collector => `client.methods.MessageCollector`
+ShardingManager => `client.methods.Shard`
+WebhookClient => `client.methods.Webhook`
 
 To use any of the methods, you follow this same structure:
 ```js
@@ -241,5 +241,5 @@ let method = new client.methods.<MethodName>(OptionalMethodProperties);
 
 So if you need to create a Message Collector, you will do:
 ```js
-let messageCollector = new client.methods.messageCollector(channelid, filter, options);
+let messageCollector = new client.methods.MessageCollector(channelid, filter, options);
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These pieces are:
 - **monitors** which are used to check a message before it's a command.
 - **events** which are triggered based on what happens in Discord.
 - **dataProviders** which are database connectors (in progress at the moment).
+- **methods** which are native Discord.js functions
 
 ### Creating a new command
 
@@ -217,4 +218,21 @@ exports.conf = {
 exports.run = (client, msg) => {
   // code here
 };
+```
+
+### Using Methods
+
+Methods are just Discord.js native functions added to Komada, so that we may
+export them to any other piece that we may need them in. For example, if your bot
+a larger bot and you need to make use of the shardingManager, but can't do since
+it's a native Discord.js function, well now you can.
+
+To use any of the methods, you follow this same structure:
+```js
+let method = new client.methods.<MethodName>(OptionalMethodProperties);
+```
+
+So if you need to create a Message Collector, you will do:
+```js
+let messageCollector = new client.methods.messageCollector(channelid, filter, options);
 ```

--- a/app.js
+++ b/app.js
@@ -21,11 +21,11 @@ exports.start = (config) => {
 
   // Extend Client with Native Discord.js Functions for use in our pieces.
   client.methods = {};
-  client.methods.collection = Discord.Collection;
-  client.methods.embed = Discord.RichEmbed;
-  client.methods.messageCollector = Discord.MessageCollector;
-  client.methods.shard = Discord.ShardingManager;
-  client.methods.webhook = Discord.WebhookClient;
+  client.methods.Collection = Discord.Collection;
+  client.methods.Embed = Discord.RichEmbed;
+  client.methods.MessageCollector = Discord.MessageCollector;
+  client.methods.Shard = Discord.ShardingManager;
+  client.methods.Webhook = Discord.WebhookClient;
 
   client.coreBaseDir = `${__dirname}/`;
   client.clientBaseDir = `${process.cwd()}/`;

--- a/app.js
+++ b/app.js
@@ -19,6 +19,14 @@ exports.start = (config) => {
   client.commandMonitors = new Discord.Collection();
   client.dataProviders = new Discord.Collection();
 
+  // Extend Client with Native Discord.js Functions for use in our pieces.
+  client.methods = {};
+  client.methods.collection = Discord.Collection;
+  client.methods.embed = Discord.RichEmbed;
+  client.methods.messageCollector = Discord.MessageCollector;
+  client.methods.shard = Discord.ShardingManager;
+  client.methods.webhook = Discord.WebhookClient;
+
   client.coreBaseDir = `${__dirname}/`;
   client.clientBaseDir = `${process.cwd()}/`;
 

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ exports.start = (config) => {
   client.commands = new Discord.Collection();
   client.aliases = new Discord.Collection();
   client.commandInhibitors = new Discord.Collection();
-  client.commandMonitors = new Discord.Collection();
+  client.messageMonitors = new Discord.Collection();
   client.dataProviders = new Discord.Collection();
 
   // Extend Client with Native Discord.js Functions for use in our pieces.
@@ -35,7 +35,7 @@ exports.start = (config) => {
     client.funcs.loadDataProviders(client);
     client.funcs.loadCommands(client);
     client.funcs.loadCommandInhibitors(client);
-    client.funcs.loadCommandMonitors(client);
+    client.funcs.loadmessageMonitors(client);
     client.funcs.loadEvents(client);
     client.i18n = client.funcs.loadLocalizations;
     client.i18n.init(client);
@@ -50,7 +50,7 @@ exports.start = (config) => {
     const conf = client.funcs.confs.get(msg.guild);
     msg.guildConf = conf;
     client.i18n.use(conf.lang);
-    client.funcs.runCommandMonitors(client, msg).catch(reason => msg.channel.sendMessage(reason).catch(console.error));
+    client.funcs.runMessageMonitors(client, msg).catch(reason => msg.channel.sendMessage(reason).catch(console.error));
     if (!msg.content.startsWith(conf.prefix) && !client.config.prefixMention.test(msg.content)) return;
     let prefixLength = conf.prefix.length;
     if (client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length + 1;

--- a/functions/loadMessageMonitors.js
+++ b/functions/loadMessageMonitors.js
@@ -1,7 +1,7 @@
 const fs = require("fs-extra-promise");
 const path = require("path");
 
-const loadCommandMonitors = (client, baseDir, counts) => new Promise((resolve, reject) => {
+const loadMessageMonitors = (client, baseDir, counts) => new Promise((resolve, reject) => {
   const dir = path.resolve(`${baseDir}./monitors/`);
   fs.ensureDirAsync(dir)
   .then(() => {
@@ -13,7 +13,7 @@ const loadCommandMonitors = (client, baseDir, counts) => new Promise((resolve, r
         files.forEach((f) => {
           const file = f.split(".");
           const props = require(`${dir}/${f}`);
-          client.commandMonitors.set(file[0], props);
+          client.messageMonitors.set(file[0], props);
           if (props.init) {
             props.init(client);
           }
@@ -24,7 +24,7 @@ const loadCommandMonitors = (client, baseDir, counts) => new Promise((resolve, r
           const module = /'[^']+'/g.exec(e.toString());
           client.funcs.installNPM(module[0].slice(1, -1))
               .then(() => {
-                client.funcs.loadCommandMonitors(client);
+                client.funcs.loadMessageMonitors(client);
               })
               .catch((err) => {
                 console.error(err);
@@ -41,17 +41,17 @@ const loadCommandMonitors = (client, baseDir, counts) => new Promise((resolve, r
 });
 
 module.exports = (client) => {
-  client.commandMonitors.clear();
+  client.messageMonitors.clear();
   const count = 0;
   if (client.coreBaseDir !== client.clientBaseDir) {
-    loadCommandMonitors(client, client.coreBaseDir, count).then((counts) => {
-      loadCommandMonitors(client, client.clientBaseDir, counts).then((countss) => {
+    loadMessageMonitors(client, client.coreBaseDir, count).then((counts) => {
+      loadMessageMonitors(client, client.clientBaseDir, counts).then((countss) => {
         const c = countss;
         client.funcs.log(`Loaded ${c} command monitors.`);
       });
     });
   } else {
-    loadCommandMonitors(client, client.coreBaseDir, count).then((counts) => {
+    loadMessageMonitors(client, client.coreBaseDir, count).then((counts) => {
       const c = counts;
       client.funcs.log(`Loaded ${c} command monitors.`);
     });

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -110,15 +110,15 @@ exports.inhibitor = (client, dir, inhibName) => new Promise((resolve, reject) =>
 
 exports.monitor = (client, dir, monitName) => new Promise((resolve, reject) => {
   client.funcs.getFileListing(client, dir, "monitors").then((files) => {
-    if (client.commandMonitors.has(monitName)) {
+    if (client.messageMonitors.has(monitName)) {
       const oldMonitor = files.filter(f => f.name === monitName);
       if (oldMonitor[0]) {
         try {
           oldMonitor.forEach((file) => {
-            client.commandMonitors.delete(file.name);
+            client.messageMonitors.delete(file.name);
             delete require.cache[require.resolve(`${file.path}${path.sep}${file.base}`)];
             const props = require(`${file.path}${path.sep}${file.base}`);
-            client.commandMonitors.set(file.name, props);
+            client.messageMonitors.set(file.name, props);
             if (props.init) {
               props.init(client);
             }
@@ -137,7 +137,7 @@ exports.monitor = (client, dir, monitName) => new Promise((resolve, reject) => {
         try {
           newMonitor.forEach((file) => {
             const props = require(`${file.path}${path.sep}${file.base}`);
-            client.commandMonitors.set(file.name, props);
+            client.messageMonitors.set(file.name, props);
             if (props.init) {
               props.init(client);
             }

--- a/functions/runCommandMonitors.js
+++ b/functions/runCommandMonitors.js
@@ -1,6 +1,6 @@
 module.exports = (client, msg) => new Promise((resolve, reject) => {
   const mps = [true];
-  client.commandMonitors.forEach((mProc) => {
+  client.messageMonitors.forEach((mProc) => {
     if (mProc.conf.enabled) {
       mps.push(mProc.run(client, msg));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
Native Discord.js Functions are now available throughout Komada via `client.methods.<MethodName>`
You may use these by putting new in front of these, just like you would normally.

Collection => `new client.methods.collection();`
Embed => `new client.methods.embed({embed options});`
MessageCollector => `new client.methods.messageCollector({message collector options});`
ShardingManager => `new client.methods.shard({sharding manager options});`
WebhookClient => `new client.methods.webhook({webhook options});`
