### PR TITLE
Numerous Conf Changes/Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- confs.getRaw(<Guild>) returns the entire configuration for developers.
+
+### Changed
+- confs.addKey(key, defaultValue, min value, max value) and .setKey() and .set() changed to account for integers. This is backwards compatible with older versions.
+
+### Fixed
+- Tons of Confs fixes and changes to be more consistent.
 
 ## [0.12.0] - 2016-12-15
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
**MANY** Conf (function) changes
addKey, setKey, and set now properly account for minimum and maximum values.
To add min or max values:
`client.funcs.confs.addKey(keyName, defaultValue, minimum value, maximum value);`
Note: this is backwards compatible with earlier versions, and they won't be used if the key isn't a number.

Several Changes to make confs more consistent with error reporting.

New Function for Developers:
`client.funcs.confs.getRaw(<Guild>);` -> Returns full configuration, so you can check type, min, max, etc.

