### PR TITLE
DM-Fixes for Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - confs.addKey(key, defaultValue, min value, max value) and .setKey() and .set() changed to account for integers. This is backwards compatible with older versions.
 
 ### Fixed
-- Tons of Confs fixes and changes to be more consistent.
 - Commands can now be used in DM with proper permission levels
+- Tons of Confs fixes and changes to be more consistent.
 
 ### Removed
 - Removed `client.methods.Shard` aka `ShardingManager` due to how Sharding works (ie. Needs an additional file to spawn the ShardingManager)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Tons of Confs fixes and changes to be more consistent.
+- Commands can now be used in DM with proper permission levels
 
 ### Removed
 - Removed `client.methods.Shard` aka `ShardingManager` due to how Sharding works (ie. Needs an additional file to spawn the ShardingManager)

--- a/functions/permissionLevel.js
+++ b/functions/permissionLevel.js
@@ -1,7 +1,7 @@
-module.exports = (client, user, guild = null) => new Promise((resolve, reject) => {
-  const guildConf = client.funcs.confs.get(guild);
+module.exports = (client, user, guild) => new Promise((resolve, reject) => {
   let permlvl = 0;
   if (guild) {
+    const guildConf = client.funcs.confs.get(guild);
     try {
       const modRole = guild.roles.find("name", guildConf.modRole);
       guild.fetchMember(user).then((member) => {
@@ -23,5 +23,10 @@ module.exports = (client, user, guild = null) => new Promise((resolve, reject) =
     } catch (e) {
       reject(e);
     }
+  } else {
+    if (user.id === client.config.ownerID) {
+      permlvl = 10;
+    }
+    resolve(permlvl);
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
DM Fixes for Commands so that commands can be used within DM. Only the owners level permission will be calculated though, so all users DMing the bot will have a level of 0.

Also, guild does not need to be defaulted to null. It's automatically null if there's no guild for a message.