### PR TITLE
Change Indev back to Master (Which is now Indev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.3",
-    "discord.js": "hydrabolt/discord.js#indev",
+    "discord.js": "hydrabolt/discord.js",
     "fs-extra": "^1.0.0",
     "fs-extra-promise": "^0.4.1",
     "moment": "^2.16.0",


### PR DESCRIPTION
Fix for the restructuring of Discord.js branches