### PR TITLE
Fix function inits

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,9 @@ exports.start = (config) => {
 
   client.once("ready", () => {
     client.config.prefixMention = new RegExp(`^<@!?${client.user.id}>`);
+    for (const func in client.funcs) {
+      if (client.funcs[func].init) client.funcs[func].init(client);
+    }
   });
 
   client.on("error", e => client.funcs.log(e, "error"));

--- a/functions/confs.js
+++ b/functions/confs.js
@@ -50,7 +50,7 @@ exports.init = (client) => {
 
 exports.remove = (guild) => {
   if (!guildConfs.has(guild.id)) {
-    return console.log(`Attempting to remove ${guild.name} but it's not there.`);
+    return false;
   }
 
   fs.removeAsync(path.resolve(`${dataDir}${path.sep}${guild.id}.json`));

--- a/functions/loadFunctions.js
+++ b/functions/loadFunctions.js
@@ -14,9 +14,10 @@ const loadFunctions = (client, baseDir, counts) => new Promise((resolve, reject)
           const file = f.split(".");
           if (file[0] === "loadFunctions") return;
           client.funcs[file[0]] = require(`${dir}/${f}`);
-          if (client.funcs[file[0]].init) {
-            client.funcs[file[0]].init(client);
-          }
+          // Currently disabled for workaround (See ready event)
+          // if (client.funcs[file[0]].init) {
+          //   client.funcs[file[0]].init(client);
+          // }
           c++;
         });
         resolve(c);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: PATCH

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Move function init() to ready
- Remove annoying guild conf removal message

### (If Applicable) What Issue does it fix?
If a function's init() required something from a client collection, it failed to execute properly. Moving init() functions the ready event seems like an appropriate workaround for now.