### PR TITLE
[FEATURE] New Argument Prompting System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - New Beta Configuration (Needs heavy testing)
+- New Argument Prompting for Commands 
 
 ### Changed
 - Confs.js uses new configuration system now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - New Beta Configuration (Needs heavy testing)
-- New Argument Prompting for Commands 
+- New Argument Prompting for Commands
 
 ### Changed
 - Confs.js uses new configuration system now
 - Configuration now split into smaller parts as requested.
+
+### Fixed
+- loadCommands no longer counts/loads "Ghost" commands.
 
 ### Removed
 - Old Configuration System

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - loadCommands no longer counts/loads "Ghost" commands.
 - DMs throwing errors with new Config System && permLevel
+- Fixed Reload not erroring on new commands that aren't found
 
 ### Removed
 - Old Configuration System

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - loadCommands no longer counts/loads "Ghost" commands.
+- DMs throwing errors with new Config System && permLevel
 
 ### Removed
 - Old Configuration System

--- a/app.js
+++ b/app.js
@@ -61,8 +61,16 @@ exports.start = (config) => {
     msg.guildConf = conf;
     client.i18n.use(conf.lang);
     client.funcs.runMessageMonitors(client, msg).catch(reason => msg.channel.sendMessage(reason).catch(console.error));
-    if (!msg.content.startsWith(conf.prefix) && (client.config.prefixMention && !client.config.prefixMention.test(msg.content))) return;
-    let prefixLength = conf.prefix.length;
+    let thisPrefix;
+    if (conf.prefix instanceof Array) {
+      conf.prefix.forEach((prefix) => {
+        if (msg.content.startsWith(prefix)) thisPrefix = prefix;
+      });
+    } else if (msg.content.startsWith(conf.prefix)) {
+      thisPrefix = conf.prefix;
+    }
+    if (!thisPrefix && (client.config.prefixMention && !client.config.prefixMention.test(msg.content))) return;
+    let prefixLength = thisPrefix.length;
     if (client.config.prefixMention && client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length + 1;
     const command = msg.content.slice(prefixLength).split(" ")[0].toLowerCase();
     const suffix = msg.content.slice(prefixLength).split(" ").slice(1).join(" ");

--- a/app.js
+++ b/app.js
@@ -102,5 +102,6 @@ exports.start = (config) => {
 };
 
 process.on("unhandledRejection", (err) => {
+  if (!err) return;
   console.error(`Uncaught Promise Error: \n${err.stack}`);
 });

--- a/app.js
+++ b/app.js
@@ -69,7 +69,8 @@ exports.start = (config) => {
     } else if (msg.content.startsWith(conf.prefix)) {
       thisPrefix = conf.prefix;
     }
-    if (!thisPrefix && (client.config.prefixMention && !client.config.prefixMention.test(msg.content))) return;
+    if (!thisPrefix) return;
+    if (client.config.prefixMention && !client.config.prefixMention.test(msg.content)) return;
     let prefixLength = thisPrefix.length;
     if (client.config.prefixMention && client.config.prefixMention.test(msg.content)) prefixLength = client.config.prefixMention.exec(msg.content)[0].length + 1;
     const command = msg.content.slice(prefixLength).split(" ")[0].toLowerCase();

--- a/classes/Config.js
+++ b/classes/Config.js
@@ -144,17 +144,21 @@ class Config {
    * //Example of what this returns
    * { prefix: '--', disabledCommands: [], modRole: 'Mods', adminRole: 'Devs', lang: 'en' }
    */
-  static get(guild) {
-    const conf = {};
-    if (guild && guildConfs.has(guild.id)) {
-      const guildConf = guildConfs.get(guild.id);
-      for (const key in guildConf) {
-        if (guildConf[key]) conf[key] = guildConf[key].data;
-        else conf[key] = defaultConf[key].data;
-      }
-    }
-    return conf;
-  }
+   static get(guild) {
+     const conf = {};
+     if (guild && guildConfs.has(guild.id)) {
+       const guildConf = guildConfs.get(guild.id);
+       for (const key in guildConf) {
+         if (guildConf[key]) conf[key] = guildConf[key].data;
+         else conf[key] = defaultConf[key].data;
+       }
+     } else {
+       for (const key in defaultConf) {
+         conf[key] = defaultConf[key].data;
+       }
+     }
+     return conf;
+   }
 
   /**
    * Set the default value for a key in the default configuration.

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -1,0 +1,27 @@
+module.exports = (client, msg, cmd, args, error) => {
+  msg.channel.sendMessage(`<@!${msg.member.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`).then((message) => {
+    msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, {
+      max: 1,
+      time: 30000,
+      errors: ["time"],
+    })
+    .then((param) => {
+      message.delete();
+      if (param.first().content === "ABORT") return;
+      args.push(param.first().content);
+      client.funcs.runCommandInhibitors(client, msg, cmd, args)
+      .then((params) => {
+        cmd.run(client, msg, params);
+      });
+    })
+    .catch((reason) => {
+      if (reason) {
+        if (reason.stack) client.funcs.log(reason.stack, "error");
+        msg.channel.sendCode("", reason).catch(console.error);
+      }
+    })
+    .catch(() => {
+      msg.channel.sendMessage("No message was sent before the 30 second mark. Aborting command.");
+    });
+  });
+};

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -7,7 +7,7 @@ module.exports = (client, msg, cmd, args, error) => {
     })
     .then((param) => {
       message.delete();
-      if (param.first().content === "ABORT") return;
+      if (param.first().content.toLowerCase() === "abort") return;
       args.push(param.first().content);
       client.funcs.runCommandInhibitors(client, msg, cmd, args)
       .then((params) => {

--- a/functions/loadCommands.js
+++ b/functions/loadCommands.js
@@ -51,10 +51,17 @@ module.exports = (client) => {
   client.commands.clear();
   client.aliases.clear();
   const count = [0, 0];
-  loadCommands(client, client.coreBaseDir, count).then((counts) => {
-    loadCommands(client, client.clientBaseDir, counts).then((countss) => {
-      const [c, a] = countss;
-      client.funcs.log(`Loaded ${c} commands, with ${a} aliases.`);
+  if (client.coreBaseDir !== client.clientBaseDir) {
+    loadCommands(client, client.coreBaseDir, count).then((counts) => {
+      loadCommands(client, client.clientBaseDir, counts).then((countss) => {
+        const [c, a] = countss;
+        client.funcs.log(`Loaded ${c} commands, with ${a} aliases.`);
+      });
     });
-  });
+  } else {
+    loadCommands(client, client.coreBaseDir, count).then((counts) => {
+      const [c, a] = counts;
+      client.funcs.log(`Loaded ${c} commands with ${a} aliases.`);
+    });
+  }
 };

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -261,9 +261,10 @@ exports.command = (client, dir, commandName) => new Promise((resolve, reject) =>
                 .catch((e) => {
                   reject(e);
                 });
+          resolve(`Succesfully loaded a new command called ${commandName}`);
         });
       });
-    resolve(`Succesully loaded a new command called ${commandName}`);
+    reject(`Could not locate a new **${command}** in ${dir}`);
   } else {
     client.funcs.loadSingleCommand(client, command, true)
           .then(() => {

--- a/functions/runCommandInhibitors.js
+++ b/functions/runCommandInhibitors.js
@@ -1,4 +1,4 @@
-module.exports = (client, msg, cmd, selective = false) => new Promise((resolve, reject) => {
+module.exports = (client, msg, cmd, args, selective = false) => new Promise((resolve, reject) => {
   const mps = [true];
   let i = 1;
   let usage;

--- a/functions/runCommandInhibitors.js
+++ b/functions/runCommandInhibitors.js
@@ -5,7 +5,7 @@ module.exports = (client, msg, cmd, selective = false) => new Promise((resolve, 
   client.commandInhibitors.forEach((mProc, key) => {
     if (key === "usage") usage = i;
     if (!mProc.conf.spamProtection || !selective) {
-      mps.push(mProc.run(client, msg, cmd));
+      mps.push(mProc.run(client, msg, cmd, args));
     }
     i++;
   });

--- a/inhibitors/permissions.js
+++ b/inhibitors/permissions.js
@@ -6,7 +6,9 @@ exports.conf = {
 exports.run = (client, msg, cmd) => new Promise((resolve, reject) => {
   client.funcs.permissionLevel(client, msg.author, msg.guild)
       .then((permlvl) => {
-        msg.member.permLevel = permlvl;
+        if (msg.guild) {
+          msg.member.permLevel = permlvl;
+        }
         if (permlvl >= cmd.conf.permLevel) {
           resolve();
         } else {

--- a/inhibitors/usage.js
+++ b/inhibitors/usage.js
@@ -35,14 +35,17 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        return reject(client.funcs.awaitMessage(client, msg, cmd, args, "Missing one or more required arguments after end of input."));
+        if (client.config.cmdPrompt) return reject(client.funcs.awaitMessage(client, msg, cmd, args, "Missing one or more required arguments after end of input."));
+        return reject("Missing one or more required arguments after end of input.");
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      return reject(client.funcs.awaitMessage(client, msg, cmd, args, currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`));
+      if (client.config.cmdPrompt) return reject(client.funcs.awaitMessage(client, msg, cmd, args, currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`));
+      return reject(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`);
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
         case "literal":
+          console.log(args[i]);
           if (args[i].toLowerCase() === currentUsage.possibles[0].name.toLowerCase()) {
             args[i] = args[i].toLowerCase();
             validateArgs(++i);
@@ -50,8 +53,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `Your option did not litterally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `Your option did not litterally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`));
+            }
+            return reject(`Your option did not litterally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`);
           }
           break;
         case "msg":
@@ -68,8 +74,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
-                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+                  if (client.config.cmdPrompt) {
+                    args.shift();
+                    return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+                  }
+                  return reject(`${currentUsage.possibles[0].name} must be a valid message id.`);
                 }
               });
             } else {
@@ -83,8 +92,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.shift();
-                      return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+                      if (client.config.cmdPrompt) {
+                        args.shift();
+                        return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+                      }
+                      return reject(`${currentUsage.possibles[0].name} must be a valid message id.`);
                     }
                   });
             }
@@ -92,8 +104,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid message id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a valid message id.`);
           }
           break;
         case "user":
@@ -105,8 +120,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a mention or valid user id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a mention or valid user id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
           }
           break;
         case "boolean":
@@ -121,8 +139,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be true or false.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be true or false.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be true or false.`);
           }
           break;
         case "member":
@@ -133,8 +154,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a mention or valid user id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a mention or valid user id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a mention or valid user id.`);
           }
           break;
         case "channel":
@@ -145,8 +169,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`);
           }
           break;
         case "guild":
@@ -157,8 +184,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid guild id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid guild id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a valid guild id.`);
           }
           break;
         case "role":
@@ -169,8 +199,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
-            return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a role mention or role id.`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a role mention or role id.`));
+            }
+            return reject(`${currentUsage.possibles[0].name} must be a role mention or role id.`);
           }
           break;
         case "str":
@@ -181,11 +214,17 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`);
               }
             } else {
               validateArgs(++i);
@@ -196,11 +235,13 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`);
               }
             } else {
-              args.shift();
               validateArgs(++i);
             }
           } else if (currentUsage.possibles[0].max) {
@@ -209,8 +250,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`);
               }
             } else {
               validateArgs(++i);
@@ -226,8 +270,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
-              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be an integer.`));
+              if (client.config.cmdPrompt) {
+                args.shift();
+                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be an integer.`));
+              }
+              return reject(`${currentUsage.possibles[0].name} must be an integer.`);
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
             args[i] = parseInt(args[i]);
@@ -237,15 +284,21 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
-                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`));
+                  if (client.config.cmdPrompt) {
+                    args.shift();
+                    return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`));
+                  }
+                  return reject(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`);
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`);
               }
             } else {
               validateArgs(++i);
@@ -257,8 +310,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`);
               }
             } else {
               validateArgs(++i);
@@ -270,8 +326,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`);
               }
             } else {
               validateArgs(++i);
@@ -289,8 +348,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
-              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid number.`));
+              if (client.config.cmdPrompt) {
+                args.shift();
+                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid number.`));
+              }
+              return reject(`${currentUsage.possibles[0].name} must be a valid number.`);
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
             args[i] = parseFloat(args[i]);
@@ -300,15 +362,21 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
-                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`));
+                  if (client.config.cmdPrompt) {
+                    args.shift();
+                    return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`));
+                  }
+                  return reject(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`);
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`);
               }
             } else {
               validateArgs(++i);
@@ -320,8 +388,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`);
               }
             } else {
               validateArgs(++i);
@@ -333,8 +404,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
-                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`));
+                if (client.config.cmdPrompt) {
+                  args.shift();
+                  return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`));
+                }
+                return reject(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`);
               }
             } else {
               validateArgs(++i);
@@ -351,8 +425,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
-              return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid url.`));
+              if (client.config.cmdPrompt) {
+                args.shift();
+                return reject(client.funcs.awaitMessage(client, msg, cmd, args, `${currentUsage.possibles[0].name} must be a valid url.`));
+              }
+              return reject(`${currentUsage.possibles[0].name} must be a valid url.`);
             }
           } else {
             validateArgs(++i);
@@ -374,7 +451,11 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            reject(client.funcs.awaitMessage(client, msg, cmd, args, `Your option didn't match any of the possibilities: (${currentUsage.possibles.map(possibles => possibles.name).join(", ")})`));
+            if (client.config.cmdPrompt) {
+              args.shift();
+              reject(client.funcs.awaitMessage(client, msg, cmd, args, `Your option didn't match any of the possibilities: (${currentUsage.possibles.map(possibles => possibles.name).join(", ")})`));
+            }
+            reject(`Your option didn't match any of the possibilities: (${currentUsage.possibles.map(possibles => possibles.name).join(", ")})`);
           }
           return;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- New Argument Prompting via awaitMessage. If you supply an incorrect parameter, the bot will respond with and awaitMessage for you to respond with the correct paramater. If you don't want the command to run anymore or you're sick of the awaitMessage, you can type "ABORT" to abort the command execution.
- Asks for every argument after the one you got wrong. If you have 2 arguments and you get the first wrong, It'll ask for both arguments. If you have 5 and answer the 4th one wrong, it'll ask for 2 more arguments to complete the command.
- Command Prompts are available by setting a configuration option "cmdPrompt" to true.
- Config.Prefix now allows a string or an array of strings as it's prefix

### Fixes
- Fixes loadCommands loading "Ghost Commands."
- Fixes for DMs throwing translation errors and permLevel errors.
- Fixed Reload Command incorrectly loading "new" commands that didn't exist.