### PR TITLE
[BUGFIX] Providers now Init before Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New Download Command
 
 ### Changed
+- Providers will init on load instead of on the initialise function. (Commands were init-ing before Providers)
 - Broke down App.js Message Event into several smaller, changeable parts.
 - newError changed to send arguments to awaitMessage when errors are from usage
 - awaitMessage changed to work perfectly with the new system

--- a/functions/initialize.js
+++ b/functions/initialize.js
@@ -2,9 +2,6 @@ module.exports = async (client) => {
   Object.keys(client.funcs).forEach(async (func) => {
     if (client.funcs[func].init) await client.funcs[func].init(client);
   });
-  client.providers.forEach(async (prov) => {
-    if (prov.init) await prov.init(client);
-  });
   await client.configuration.initialize(client);
   client.commandInhibitors.forEach(async (inhib) => {
     if (inhib.init) await inhib.init(client);

--- a/functions/loadProviders.js
+++ b/functions/loadProviders.js
@@ -9,6 +9,7 @@ const loadProviders = (client, baseDir) => new Promise(async (resolve, reject) =
     files.forEach((f) => {
       const props = require(`${f.path}${path.sep}${f.base}`);
       client.providers.set(f.name, props);
+      if (props.init) { props.init(client); }
     });
     resolve();
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
SEMVER: Patch

Why:

* Commands were initing before Providers in the initialise function.

This change addresses the need by:

* Having Providers Init upon being loaded.
