### PR TITLE
Added the new Discord.js methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added the new utils from `Discord.js#master`: escapeMarkdown and splitMessage are now in `client.methods`.
 - Added support for silent inhibitors (if `return true`, it won't send a reply).
 - Added Environmental Variable support for clientDir.
 - Added regExpEscape function.

--- a/app.js
+++ b/app.js
@@ -31,6 +31,8 @@ exports.start = async (config) => {
   client.methods.Embed = Discord.RichEmbed;
   client.methods.MessageCollector = Discord.MessageCollector;
   client.methods.Webhook = Discord.WebhookClient;
+  client.methods.escapeMarkdown = Discord.escapeMarkdown;
+  client.methods.splitMessage = Discord.splitMessage;
 
   client.coreBaseDir = `${__dirname}${path.sep}`;
   client.clientBaseDir = `${process.env.clientDir || process.cwd()}${path.sep}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.17.10",
+  "version": "0.17.11",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added the new utils from `Discord.js#master`: escapeMarkdown and splitMessage are now in `client.methods`.