### PR TITLE
Better error tracing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added regExpEscape function.
 
 ### Changed
+- Add error.stack to the function log.js to avoid [object Object].
 - loading Functions are removed from Functions folder and moved to a Utils folder. (This folder will be there for future features as well.)
 
 ### Fixed
+- Disconnect event should print "Disconnected" instead of `[object Object]`.
 - Reloading pieces should now return the error stack in a codeblock.
 - Fixed function reload event.
 - Fixed command reload all. underlying bug since 0.15.x days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Add error.stack to the function log.js to avoid [object Object].
+- Disconnect event should now prints a more human readable error instead of `[object Object]`.
+- error and warn event errors are now inspected with depth 0, for better debug.
 - loading Functions are removed from Functions folder and moved to a Utils folder. (This folder will be there for future features as well.)
 
 ### Fixed
-- Disconnect event should print "Disconnected" instead of `[object Object]`.
 - Reloading pieces should now return the error stack in a codeblock.
 - Fixed function reload event.
 - Fixed command reload all. underlying bug since 0.15.x days.

--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ exports.start = async (config) => {
 
   client.on("error", e => client.funcs.log(e, "error"));
   client.on("warn", w => client.funcs.log(w, "warning"));
-  client.on("disconnect", e => client.funcs.log(e, "error"));
+  client.on("disconnect", () => client.funcs.log("Disconnected", "error"));
 
   client.on("message", async (msg) => {
     if (!client.ready) return;

--- a/app.js
+++ b/app.js
@@ -55,9 +55,9 @@ exports.start = async (config) => {
     client.ready = true;
   });
 
-  client.on("error", e => client.funcs.log(e, "error"));
-  client.on("warn", w => client.funcs.log(w, "warning"));
-  client.on("disconnect", e => client.funcs.log(`Disconnected: ${e.reason}`, "error"));
+  client.on("error", e => client.funcs.log(require("util").inspect(e, { depth: 0 }), "error"));
+  client.on("warn", w => client.funcs.log(require("util").inspect(w, { depth: 0 }), "warn"));
+  client.on("disconnect", e => client.funcs.log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
 
   client.on("message", async (msg) => {
     if (!client.ready) return;

--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ exports.start = async (config) => {
 
   client.on("error", e => client.funcs.log(e, "error"));
   client.on("warn", w => client.funcs.log(w, "warning"));
-  client.on("disconnect", () => client.funcs.log("Disconnected", "error"));
+  client.on("disconnect", e => client.funcs.log(`Disconnected: ${e.reason}`, "error"));
 
   client.on("message", async (msg) => {
     if (!client.ready) return;

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const Discord = require("discord.js");
 const path = require("path");
+const util = require("util");
 
 const loadFunctions = require("./utils/loadFunctions.js");
 const loadEvents = require("./utils/loadEvents.js");
@@ -55,8 +56,8 @@ exports.start = async (config) => {
     client.ready = true;
   });
 
-  client.on("error", e => client.funcs.log(require("util").inspect(e, { depth: 0 }), "error"));
-  client.on("warn", w => client.funcs.log(require("util").inspect(w, { depth: 0 }), "warn"));
+  client.on("error", e => client.funcs.log(util.inspect(e, { depth: 0 }), "error"));
+  client.on("warn", w => client.funcs.log(util.inspect(w, { depth: 0 }), "warn"));
   client.on("disconnect", e => client.funcs.log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
 
   client.on("message", async (msg) => {

--- a/functions/log.js
+++ b/functions/log.js
@@ -12,7 +12,7 @@ module.exports = (data, type = "log") => {
       console.warn(`${clk.black.bgYellow(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);
       break;
     case "error":
-      console.error(`${clk.bgRed(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);
+      console.error(`${clk.bgRed(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data.stack || data}`);
       break;
     case "log":
       console.log(`${clk.bgBlue(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MINOR/PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add error.stack to the function log.js to avoid [object Object].
- Disconnect event should print "Disconnected" instead of `[object Object]`.

### (If Applicable) What Issue does it fix?
 Fixes disconnect event from printing [object Object].
