### PR TITLE
(Hot fix) DM permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- (Hot fix) Fixed permissions on DMs (running msg.member.permLevel when the user DMs a command that doesn't have permissions for).
 - Several bugs that would have occurred if loading anything contained a NPM module error.
 
 ### Removed

--- a/inhibitors/permissions.js
+++ b/inhibitors/permissions.js
@@ -5,7 +5,10 @@ exports.conf = {
 };
 
 exports.run = (client, msg, cmd) => {
-  if (msg.channel.type !== "text" && msg.author.permLevel >= cmd.conf.permLevel) return false;
-  else if (msg.member.permLevel >= cmd.conf.permLevel) return false;
+  if (!msg.guild) {
+    if (msg.author.permLevel >= cmd.conf.permLevel) return false;
+    return "You do not have permission to use this command.";
+  }
+  if (msg.member.permLevel >= cmd.conf.permLevel) return false;
   return "You do not have permission to use this command.";
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- (Hot fix) Fixed permissions on DMs

### (If Applicable) What Issue does it fix?
 Fixes permissions on DMs (if the channel type is different to text and the user doesn't have permissions to run the command, it runs the else if, in which checks msg.member, being null).
