### PR TITLE
Updated functions log, loadSingleFile and better error tracking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - The function `log` should never display `[object Object]` now.
+- When a command fails at load, it should provide full stack error now.
 - Changed permissions inhibitor and permissionLevel function to use new Extendables.
 - Help command now no longer requires runCommandInhibitors and uses new Extendables.
 - Removed several useless lines of code in app.js made redundant by Extendables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extendables Added (postable, sendable, embedable, etc.)
 
 ### Changed
+- The function `log` should never display `[object Object]` now.
 - Changed permissions inhibitor and permissionLevel function to use new Extendables.
 - Help command now no longer requires runCommandInhibitors and uses new Extendables.
 - Removed several useless lines of code in app.js made redundant by Extendables.

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const Discord = require("discord.js");
 const path = require("path");
-const util = require("util");
 
 require("./utils/Extendables.js");
 const loadFunctions = require("./utils/loadFunctions.js");
@@ -57,8 +56,8 @@ exports.start = async (config) => {
     client.ready = true;
   });
 
-  client.on("error", e => client.funcs.log(util.inspect(e, { depth: 0 }), "error"));
-  client.on("warn", w => client.funcs.log(util.inspect(w, { depth: 0 }), "warn"));
+  client.on("error", e => client.funcs.log(e, "error"));
+  client.on("warn", w => client.funcs.log(w, "warn"));
   client.on("disconnect", e => client.funcs.log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
 
   client.on("message", async (msg) => {

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -47,7 +47,7 @@ module.exports = (client, command, reload = false, loadPath = null) => new Promi
             });
         client.funcs.loadSingleCommand(client, command, false, loadPath);
       } else {
-        return reject(`Could not load the command ${e.stack}`);
+        return reject(`Could not load the command: ${e.stack}`);
       }
     }
   }

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -47,7 +47,7 @@ module.exports = (client, command, reload = false, loadPath = null) => new Promi
             });
         client.funcs.loadSingleCommand(client, command, false, loadPath);
       } else {
-        reject(`Could not load new command data: \`\`\`js\n${e.stack}\`\`\``);
+        return reject(`Could not load the command ${e.stack}`);
       }
     }
   }

--- a/functions/log.js
+++ b/functions/log.js
@@ -3,7 +3,19 @@ const chalk = require("chalk");
 
 const clk = new chalk.constructor({ enabled: true });
 
+function resolveObject(error) {
+  error = `${error.message || error.stack || error}`
+  let out;
+  if (typeof error === "object" && typeof error !== "string") {
+    out = require("util").inspect(error, { depth: 0 });
+    if(typeof out === "string" && out.length > 1900) out = error.toString();
+  } else out = error;
+
+  return out;
+}
+
 module.exports = (data, type = "log") => {
+  data = resolveObject(data);
   switch (type.toLowerCase()) {
     case "debug":
       console.log(`${clk.bgMagenta(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);
@@ -12,7 +24,7 @@ module.exports = (data, type = "log") => {
       console.warn(`${clk.black.bgYellow(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);
       break;
     case "error":
-      console.error(`${clk.bgRed(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data.stack || data}`);
+      console.error(`${clk.bgRed(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);
       break;
     case "log":
       console.log(`${clk.bgBlue(`[${moment().format("YYYY-MM-DD HH:mm:ss")}]`)} ${data}`);

--- a/functions/log.js
+++ b/functions/log.js
@@ -4,11 +4,11 @@ const chalk = require("chalk");
 const clk = new chalk.constructor({ enabled: true });
 
 function resolveObject(error) {
-  error = `${error.message || error.stack || error}`
+  error = `${error.message || error.stack || error}`;
   let out;
   if (typeof error === "object" && typeof error !== "string") {
     out = require("util").inspect(error, { depth: 0 });
-    if(typeof out === "string" && out.length > 1900) out = error.toString();
+    if (typeof out === "string" && out.length > 1900) out = error.toString();
   } else out = error;
 
   return out;

--- a/functions/log.js
+++ b/functions/log.js
@@ -4,7 +4,7 @@ const chalk = require("chalk");
 const clk = new chalk.constructor({ enabled: true });
 
 function resolveObject(error) {
-  error = `${error.message || error.stack || error}`;
+  error = error.stack || error.message || error;
   let out;
   if (typeof error === "object" && typeof error !== "string") {
     out = require("util").inspect(error, { depth: 0 });

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -250,7 +250,7 @@ exports.command = (client, dir, commandName) => new Promise(async (resolve, reje
     const newCommands = files.filter(f => f.name === commandName);
     if (newCommands[0]) {
       newCommands.forEach(async (file) => {
-        await client.funcs.loadSingleCommand(client, commandName, false, `${file.path}${path.sep}${file.base}`).catch(e => reject(`\`\`\`${e}\`\`\``));
+        await client.funcs.loadSingleCommand(client, commandName, false, `${file.path}${path.sep}${file.base}`).catch(e => reject(`\`\`\`js\n${e}\`\`\``));
         resolve(`Successfully loaded a new command called ${commandName}`);
       });
     } else {

--- a/functions/reload.js
+++ b/functions/reload.js
@@ -250,7 +250,7 @@ exports.command = (client, dir, commandName) => new Promise(async (resolve, reje
     const newCommands = files.filter(f => f.name === commandName);
     if (newCommands[0]) {
       newCommands.forEach(async (file) => {
-        await client.funcs.loadSingleCommand(client, commandName, false, `${file.path}${path.sep}${file.base}`).catch(e => reject(e));
+        await client.funcs.loadSingleCommand(client, commandName, false, `${file.path}${path.sep}${file.base}`).catch(e => reject(`\`\`\`${e}\`\`\``));
         resolve(`Successfully loaded a new command called ${commandName}`);
       });
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MINOR]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- No more `[object Object]` when passing error objects to the function log.
- When a command fails at load, it should provide full stack error now.

### Fixes:

- Before this PR, when the object exports.help were broken, it displayed `Cannot read property 'help' of undefined.` on the logs. However, this PR fixes this and provides an error stack instead (so you can't know what's the failing command and in which line!)
