### PR TITLE
Reaction Extend, Usage Fix && ReactionCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Little bit of Documentation to Extendables
+- Message.awaitReactions && Message.createCollector && ReactionCollector
 - Message.reactable added to extendables
 - Monitors can customize whether to run the monitor on a bot or self now.
 - Added readable to make postable, embedable, and attachable more accurate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Fixed Float Usage not correctly determining if NaN (finally)
 - Fixed Usage for the 603rd time. Maybe? Probably not.
 - TypeError in awaitMessage.js function, issue #158
 - (Hot fix) Fixed help command (was returning BadRequest) on 0.18.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Message.reactable added to extendables
 - Monitors can customize whether to run the monitor on a bot or self now.
 - Added readable to make postable, embedable, and attachable more accurate.
 - postable, embedable, attachable now apply to any Text Channel for simplicity and to prevent errors down the road.
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Fixed Usage for the 603rd time. Maybe? Probably not.
 - TypeError in awaitMessage.js function, issue #158
 - (Hot fix) Fixed help command (was returning BadRequest) on 0.18.5
 - (Hot fix) Fixed permissions on DMs (running msg.member.permLevel when the user DMs a command that doesn't have permissions for).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Fixed HandleCommand not passing Arguments to awaitMessage properly.
 - Fixed AwaitMessage - Kyra
 - Fixed Float Usage not correctly determining if NaN (finally)
 - Fixed Usage for the 603rd time. Maybe? Probably not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- Fixed AwaitMessage - Kyra
 - Fixed Float Usage not correctly determining if NaN (finally)
 - Fixed Usage for the 603rd time. Maybe? Probably not.
 - TypeError in awaitMessage.js function, issue #158

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -12,7 +12,7 @@ module.exports = async (client, msg, cmd, args, error) => {
   try {
     const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, options);
     if (param.first().content.toLowerCase() === "abort") return "Aborted";
-    args[args.indexOf(undefined)] = param.first().content;
+    args[args.indexOf(null)] = param.first().content;
     const params = await client.funcs.usage.run(client, msg, cmd, args);
     cmd.run(client, msg, params);
   } catch (e) {

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -12,7 +12,7 @@ module.exports = async (client, msg, cmd, args, error) => {
   try {
     const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, options);
     if (param.first().content.toLowerCase() === "abort") return "Aborted";
-    args.push(param.first().content);
+    args[args.indexOf(undefined)] = param.first().content;
     const params = await client.funcs.usage.run(client, msg, cmd, args);
     cmd.run(client, msg, params);
   } catch (e) {

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -12,7 +12,7 @@ module.exports = async (client, msg, cmd, args, error) => {
   try {
     const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, options);
     if (param.first().content.toLowerCase() === "abort") return "Aborted";
-    args[args.indexOf(null)] = param.first().content;
+    args[args.lastIndexOf(null)] = param.first().content;
     const params = await client.funcs.usage.run(client, msg, cmd, args);
     cmd.run(client, msg, params);
   } catch (e) {

--- a/functions/awaitMessage.js
+++ b/functions/awaitMessage.js
@@ -9,19 +9,19 @@ module.exports = async (client, msg, cmd, args, error) => {
   const permLvl = user.permLevel;
   if (cmd.conf.permLevel > permLvl) return msg.channel.sendCode("", "You do not have enough permission to use this command.").catch(err => client.emit("error", client.funcs.newError(err)));
   const message = await msg.channel.sendMessage(`<@!${msg.member.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`).catch(err => client.emit("error", client.funcs.newError(err)));
-  const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, options).catch(err => client.emit("error", client.funcs.newError(err)));
-  message.delete();
-  if (!param) return "Aborted";
-  if (param.first().content.toLowerCase() === "abort") return "Aborted";
-  args.push(param.first().content);
   try {
+    const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, options);
+    if (param.first().content.toLowerCase() === "abort") return "Aborted";
+    args.push(param.first().content);
     const params = await client.funcs.usage.run(client, msg, cmd, args);
     cmd.run(client, msg, params);
-  } catch (err) {
-    if (err) {
-      if (err.code === 1 && client.config.cmdPrompt) {
-        client.funcs.awaitMessage(client, msg, cmd, err.args, err.message);
+  } catch (e) {
+    if (e) {
+      if (e.code === 1 && client.config.cmdPrompt) {
+        client.funcs.awaitMessage(client, msg, cmd, e.args, e.message);
       }
-    }
+    } else return "Aborted";
+  } finally {
+    message.delete();
   }
 };

--- a/functions/handleCommand.js
+++ b/functions/handleCommand.js
@@ -2,17 +2,14 @@ module.exports = async (client, msg, command, args = undefined) => {
   const validCommand = this.getCommand(client, command);
   if (!validCommand) return;
   const response = this.runInhibitors(client, msg, validCommand);
-  if (response) {
-    if (typeof response === "string") return msg.reply(response);
-    return;
-  }
+  if (response) return msg.reply(response);
   try {
     const params = await client.funcs.usage.run(client, msg, validCommand, args);
     validCommand.run(client, msg, params);
   } catch (error) {
     if (error) {
       if (error.code === 1 && client.config.cmdPrompt) {
-        client.funcs.awaitMessage(client, msg, validCommand, [], error.message);
+        client.funcs.awaitMessage(client, msg, validCommand, error.args, error.message);
       } else {
         if (error.stack) client.emit("error", error.stack);
         msg.channel.sendCode("JSON", (error.message || error)).catch(err => client.emit("error", err));

--- a/functions/handleCommand.js
+++ b/functions/handleCommand.js
@@ -2,7 +2,10 @@ module.exports = async (client, msg, command, args = undefined) => {
   const validCommand = this.getCommand(client, command);
   if (!validCommand) return;
   const response = this.runInhibitors(client, msg, validCommand);
-  if (response) return msg.reply(response);
+  if (response) {
+    if (typeof response === "string") msg.reply(response);
+    return;
+  }
   try {
     const params = await client.funcs.usage.run(client, msg, validCommand, args);
     validCommand.run(client, msg, params);

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -35,12 +35,12 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        args.splice(i, 1);
+        args.splice(i, 0, undefined);
         return reject(client.funcs.newError("Missing one or more required arguments after end of input.", 1, args));
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      args.splice(i, 1);
+      args.splice(i, 0, undefined);
       return reject(client.funcs.newError(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`, 1, args));
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
@@ -52,7 +52,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`Your option did not literally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`, 1, args));
           }
           break;
@@ -70,7 +70,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 1);
+                  args.splice(i, 0, undefined);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                 }
               });
@@ -85,7 +85,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.splice(i, 1);
+                      args.splice(i, 0, undefined);
                       return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                     }
                   });
@@ -94,7 +94,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
           }
           break;
@@ -107,7 +107,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -123,7 +123,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be true or false.`, 1, args));
           }
           break;
@@ -135,7 +135,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -147,7 +147,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`, 1, args));
           }
           break;
@@ -159,7 +159,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid guild id.`, 1, args));
           }
           break;
@@ -171,7 +171,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 1);
+            args.splice(i, 0, undefined);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a role mention or role id.`, 1, args));
           }
           break;
@@ -183,10 +183,10 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`, 1, args));
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -198,7 +198,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`, 1, args));
               }
             } else {
@@ -210,7 +210,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -227,7 +227,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 1);
+              args.splice(i, 0, undefined);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be an integer.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -238,14 +238,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 1);
+                  args.splice(i, 0, undefined);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -258,7 +258,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -271,7 +271,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -290,7 +290,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 1);
+              args.splice(i, 0, undefined);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid number.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -301,14 +301,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 1);
+                  args.splice(i, 0, undefined);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -321,7 +321,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -334,7 +334,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 1);
+                args.splice(i, 0, undefined);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -352,7 +352,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 1);
+              args.splice(i, 0, undefined);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid url.`, 1, args));
             }
           } else {

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -35,12 +35,12 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        args.splice(i, 0, 'undefined');
+        args.splice(i, 0, null);
         return reject(client.funcs.newError("Missing one or more required arguments after end of input.", 1, args));
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      args.splice(i, 0, 'undefined');
+      args.splice(i, 0, null);
       return reject(client.funcs.newError(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`, 1, args));
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
@@ -52,7 +52,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`Your option did not literally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`, 1, args));
           }
           break;
@@ -70,7 +70,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, 'undefined');
+                  args.splice(i, 0, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                 }
               });
@@ -85,7 +85,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.splice(i, 0, 'undefined');
+                      args.splice(i, 0, null);
                       return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                     }
                   });
@@ -94,7 +94,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
           }
           break;
@@ -107,7 +107,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -123,7 +123,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be true or false.`, 1, args));
           }
           break;
@@ -135,7 +135,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -147,7 +147,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`, 1, args));
           }
           break;
@@ -159,7 +159,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid guild id.`, 1, args));
           }
           break;
@@ -171,7 +171,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, 'undefined');
+            args.splice(i, 0, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a role mention or role id.`, 1, args));
           }
           break;
@@ -183,10 +183,10 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`, 1, args));
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -198,7 +198,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`, 1, args));
               }
             } else {
@@ -210,7 +210,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -227,7 +227,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, 'undefined');
+              args.splice(i, 0, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be an integer.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -238,14 +238,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, 'undefined');
+                  args.splice(i, 0, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -258,7 +258,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -271,7 +271,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -290,7 +290,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, 'undefined');
+              args.splice(i, 0, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid number.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -301,14 +301,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, 'undefined');
+                  args.splice(i, 0, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -321,7 +321,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -334,7 +334,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, 'undefined');
+                args.splice(i, 0, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -352,7 +352,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, 'undefined');
+              args.splice(i, 0, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid url.`, 1, args));
             }
           } else {

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -375,6 +375,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
+            args.splice(i, 1, null);
             reject(client.funcs.newError(`Your option didn't match any of the possibilities: (${currentUsage.possibles.map(possibles => possibles.name).join(", ")})`, 1, args));
           }
           return;

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -35,12 +35,12 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        args.splice(i, 0, null);
+        args.splice(i, 1, null);
         return reject(client.funcs.newError("Missing one or more required arguments after end of input.", 1, args));
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      args.splice(i, 0, null);
+      args.splice(i, 1, null);
       return reject(client.funcs.newError(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`, 1, args));
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
@@ -52,7 +52,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`Your option did not literally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`, 1, args));
           }
           break;
@@ -70,7 +70,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, null);
+                  args.splice(i, 1, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                 }
               });
@@ -85,7 +85,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.splice(i, 0, null);
+                      args.splice(i, 1, null);
                       return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                     }
                   });
@@ -94,7 +94,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
           }
           break;
@@ -107,7 +107,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -123,7 +123,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be true or false.`, 1, args));
           }
           break;
@@ -135,7 +135,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -147,7 +147,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`, 1, args));
           }
           break;
@@ -159,7 +159,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid guild id.`, 1, args));
           }
           break;
@@ -171,7 +171,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, null);
+            args.splice(i, 1, null);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a role mention or role id.`, 1, args));
           }
           break;
@@ -183,10 +183,10 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`, 1, args));
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -198,7 +198,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`, 1, args));
               }
             } else {
@@ -210,7 +210,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -227,7 +227,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, null);
+              args.splice(i, 1, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be an integer.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -238,14 +238,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, null);
+                  args.splice(i, 1, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -258,7 +258,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -271,7 +271,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -290,7 +290,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, null);
+              args.splice(i, 1, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid number.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -301,14 +301,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, null);
+                  args.splice(i, 1, null);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -321,7 +321,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -334,7 +334,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, null);
+                args.splice(i, 1, null);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -352,7 +352,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, null);
+              args.splice(i, 1, null);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid url.`, 1, args));
             }
           } else {

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -35,12 +35,12 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        args.shift();
+        args.splice(i, 1);
         return reject(client.funcs.newError("Missing one or more required arguments after end of input.", 1, args));
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      args.shift();
+      args.splice(i, 1);
       return reject(client.funcs.newError(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`, 1, args));
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
@@ -52,7 +52,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`Your option did not literally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`, 1, args));
           }
           break;
@@ -70,7 +70,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
+                  args.splice(i, 1);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                 }
               });
@@ -85,7 +85,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.shift();
+                      args.splice(i, 1);
                       return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                     }
                   });
@@ -94,7 +94,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
           }
           break;
@@ -107,7 +107,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -123,7 +123,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be true or false.`, 1, args));
           }
           break;
@@ -135,7 +135,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -147,7 +147,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`, 1, args));
           }
           break;
@@ -159,7 +159,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid guild id.`, 1, args));
           }
           break;
@@ -171,7 +171,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.shift();
+            args.splice(i, 1);
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a role mention or role id.`, 1, args));
           }
           break;
@@ -183,10 +183,10 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`, 1, args));
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -198,7 +198,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`, 1, args));
               }
             } else {
@@ -210,7 +210,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -227,7 +227,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
+              args.splice(i, 1);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be an integer.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -238,14 +238,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
+                  args.splice(i, 1);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -258,7 +258,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -271,7 +271,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -290,7 +290,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
+              args.splice(i, 1);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid number.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -301,14 +301,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.shift();
+                  args.splice(i, 1);
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -321,7 +321,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -334,7 +334,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.shift();
+                args.splice(i, 1);
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -352,7 +352,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.shift();
+              args.splice(i, 1);
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid url.`, 1, args));
             }
           } else {

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -285,7 +285,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
         case "num":
         case "number":
         case "float":
-          if (parseFloat(args[i]) === "NaN") {
+          if (isNaN(parseFloat(args[i]))) {
             if (currentUsage.type === "optional" && !repeat) {
               args.splice(i, 0, undefined);
               validateArgs(++i);
@@ -529,7 +529,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
           case "num":
           case "number":
           case "float":
-            if (parseFloat(args[i]) !== "NaN") {
+            if (isNaN(parseFloat(args[i]))) {
               args[i] = parseFloat(args[i]);
               if (currentUsage.possibles[p].min && currentUsage.possibles[p].max) {
                 if (args[i] <= currentUsage.possibles[p].max && args[i] >= currentUsage.possibles[p].min) {

--- a/functions/usage.js
+++ b/functions/usage.js
@@ -35,12 +35,12 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
     }
     if (currentUsage.type === "optional" && (args[i] === undefined || args[i] === "")) { // Handle if args length < required usage length
       if (usage.slice(i).some(u => u.type === "required")) {
-        args.splice(i, 0, undefined);
+        args.splice(i, 0, 'undefined');
         return reject(client.funcs.newError("Missing one or more required arguments after end of input.", 1, args));
       }
       return resolve(args);
     } else if (currentUsage.type === "required" && args[i] === undefined) {
-      args.splice(i, 0, undefined);
+      args.splice(i, 0, 'undefined');
       return reject(client.funcs.newError(currentUsage.possibles.length === 1 ? `${currentUsage.possibles[0].name} is a required argument.` : `Missing a required option: (${currentUsage.possibles.map(p => p.name).join(", ")})`, 1, args));
     } else if (currentUsage.possibles.length === 1) {
       switch (currentUsage.possibles[0].type) {
@@ -52,7 +52,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`Your option did not literally match the only possibility: (${currentUsage.possibles.map(p => p.name).join(", ")}).. This is likely caused by a mistake in the usage string.`, 1, args));
           }
           break;
@@ -70,7 +70,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, undefined);
+                  args.splice(i, 0, 'undefined');
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                 }
               });
@@ -85,7 +85,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                       args.splice(i, 0, undefined);
                       validateArgs(++i);
                     } else {
-                      args.splice(i, 0, undefined);
+                      args.splice(i, 0, 'undefined');
                       return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
                     }
                   });
@@ -94,7 +94,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid message id.`, 1, args));
           }
           break;
@@ -107,7 +107,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -123,7 +123,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be true or false.`, 1, args));
           }
           break;
@@ -135,7 +135,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a mention or valid user id.`, 1, args));
           }
           break;
@@ -147,7 +147,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a channel tag or valid channel id.`, 1, args));
           }
           break;
@@ -159,7 +159,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid guild id.`, 1, args));
           }
           break;
@@ -171,7 +171,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
             args.splice(i, 0, undefined);
             validateArgs(++i);
           } else {
-            args.splice(i, 0, undefined);
+            args.splice(i, 0, 'undefined');
             return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a role mention or role id.`, 1, args));
           }
           break;
@@ -183,10 +183,10 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else if (currentUsage.possibles[0].min === currentUsage.possibles[0].max) {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min} characters.`, 1, args));
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -198,7 +198,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be longer than ${currentUsage.possibles[0].min} characters.`, 1, args));
               }
             } else {
@@ -210,7 +210,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be shorter than ${currentUsage.possibles[0].max} characters.`, 1, args));
               }
             } else {
@@ -227,7 +227,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, undefined);
+              args.splice(i, 0, 'undefined');
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be an integer.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -238,14 +238,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, undefined);
+                  args.splice(i, 0, 'undefined');
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -258,7 +258,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -271,7 +271,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -290,7 +290,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, undefined);
+              args.splice(i, 0, 'undefined');
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid number.`, 1, args));
             }
           } else if (currentUsage.possibles[0].min && currentUsage.possibles[0].max) {
@@ -301,14 +301,14 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                   args.splice(i, 0, undefined);
                   validateArgs(++i);
                 } else {
-                  args.splice(i, 0, undefined);
+                  args.splice(i, 0, 'undefined');
                   return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be exactly ${currentUsage.possibles[0].min}... So why didn't the dev use a literal?`, 1, args));
                 }
               } else if (currentUsage.type === "optional" && !repeat) {
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be between ${currentUsage.possibles[0].min} and ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -321,7 +321,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be greater than ${currentUsage.possibles[0].min}.`, 1, args));
               }
             } else {
@@ -334,7 +334,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
                 args.splice(i, 0, undefined);
                 validateArgs(++i);
               } else {
-                args.splice(i, 0, undefined);
+                args.splice(i, 0, 'undefined');
                 return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be less than ${currentUsage.possibles[0].max}.`, 1, args));
               }
             } else {
@@ -352,7 +352,7 @@ exports.run = (client, msg, cmd, args = undefined) => new Promise((resolve, reje
               args.splice(i, 0, undefined);
               validateArgs(++i);
             } else {
-              args.splice(i, 0, undefined);
+              args.splice(i, 0, 'undefined');
               return reject(client.funcs.newError(`${currentUsage.possibles[0].name} must be a valid url.`, 1, args));
             }
           } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",

--- a/utils/Extendables.js
+++ b/utils/Extendables.js
@@ -29,6 +29,11 @@ class Extendables {
     return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ATTACH_FILES");
   }
 
+  get reactable() {
+    if (!this.guild) return true;
+    return this.readable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ADD_REACTIONS");
+  }
+
   get guildConf() {
     return this.client.configuration.get(this.guild);
   }
@@ -49,9 +54,9 @@ const applyToClass = (structure, props) => {
   }
 };
 
-applyToClass(GroupDMChannel, ["embedable", "postable", "attachable", "readable"]);
-applyToClass(DMChannel, ["embedable", "postable", "attachable", "readable"]);
-applyToClass(TextChannel, ["embedable", "postable", "attachable", "readable"]);
+applyToClass(GroupDMChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
+applyToClass(DMChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
+applyToClass(TextChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
 applyToClass(Message, ["guildConf"]);
 applyToClass(GuildMember, ["permLevel"]);
 applyToClass(Guild, ["conf"]);

--- a/utils/Extendables.js
+++ b/utils/Extendables.js
@@ -54,10 +54,10 @@ const applyToClass = (structure, props) => {
   }
 };
 
-applyToClass(GroupDMChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
-applyToClass(DMChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
-applyToClass(TextChannel, ["embedable", "postable", "attachable", "readable", "reactable"]);
-applyToClass(Message, ["guildConf"]);
+applyToClass(GroupDMChannel, ["embedable", "postable", "attachable", "readable"]);
+applyToClass(DMChannel, ["embedable", "postable", "attachable", "readable"]);
+applyToClass(TextChannel, ["embedable", "postable", "attachable", "readable"]);
+applyToClass(Message, ["guildConf", "reactable"]);
 applyToClass(GuildMember, ["permLevel"]);
 applyToClass(Guild, ["conf"]);
 applyToClass(User, ["permLevel"]);

--- a/utils/Extendables.js
+++ b/utils/Extendables.js
@@ -1,4 +1,5 @@
 const Discord = require("discord.js");
+const ReactionCollector = require("./ReactionCollector.js");
 
 const DMChannel = Discord.DMChannel;
 const GroupDMChannel = Discord.GroupDMChannel;
@@ -8,12 +9,20 @@ const GuildMember = Discord.GuildMember;
 const Guild = Discord.Guild;
 const User = Discord.User;
 
-
+/* A List of Extendables that allows Komada to extend native Discord.js structures to be easier or more efficient when used in Komada */
 class Extendables {
+
+  /** TextBasedChannel Extendables - All of these apply to GroupDM, DM, and Guild Text Channels
+    * <GroupDMChannel|DMChannel|TextChannel>.readable - Checks if a channel is readable by the client user -> returns {Boolean}
+    * <GroupDMChannel|DMChannel|TextChannel>.embedable - Checks if a channel is embedable by the client user -> returns {Boolean}
+    * <GroupDMChannel|DMChannel|TextChannel>.postable - Checks if a channel is postable (able to send messages) by the client user -> returns {Boolean}
+    * <GroupDMChannel|DMChannel|TextChannel>.attachable - Checks if a channel is attachable (able to attach files) by the client user -> returns {Boolean}
+    */
   get readable() {
     if (!this.guild) return true;
     return this.permissionsFor(this.guild.member(this.client.user)).hasPermission("READ_MESSAGES");
   }
+
   get embedable() {
     if (!this.guild) return true;
     return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("EMBED_LINKS");
@@ -29,25 +38,55 @@ class Extendables {
     return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ATTACH_FILES");
   }
 
+  /** Message Extendables - Apply to all messages
+    * <Message>.reatable - Checks if a message is reactable by the client user -> returns a boolean.
+    * <Message>.createCollector - Creates a ReactionCollector on the message. Takes the same filter and options as MessageCollectors -> returns {ReactionCollector}
+    * <Message>.awaitReactions - Same as createCollector for messages, except returns a promise with the collection of reactions collected. -> returns {Collection<EmojiName, Reaction>}
+    * <Message>.guildConf - Returns a guild configuration (or default if no guild) containing proper configuration settings. -> returns {Object}
+    */
   get reactable() {
     if (!this.guild) return true;
     return this.readable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ADD_REACTIONS");
+  }
+
+  createCollector(filter, options = {}) {
+    return new ReactionCollector(this, filter, options);
+  }
+
+  awaitReactions(filter, options = {}) {
+    return new Promise((resolve, reject) => {
+      const collector = this.createCollector(filter, options);
+      collector.on("end", (collection, reason) => {
+        if (options.errors && options.errors.includes(reason)) {
+          reject(collection);
+        } else {
+          resolve(collection);
+        }
+      });
+    });
   }
 
   get guildConf() {
     return this.client.configuration.get(this.guild);
   }
 
+  /** Guild Extendable - Applies to all Guilds
+    * <Guild>.conf - Same as guildConf for message, but a different way of getting it -> returns {Object}
+    */
   get conf() {
     return this.client.configuration.get(this);
   }
 
+  /** Special Extendable - Applies to both Author and Member objects
+    * <GuildMember|User> - Gets the integer permission level for a user, either for DM, or Guild -> returns {Number}
+    */
   get permLevel() {
     if (!this.guild) return this.client.funcs.permissionLevel(this.client, this, true);
     return this.client.funcs.permissionLevel(this.client, this, false);
   }
 }
 
+/** The backbone of this extendable file. Adds the properties in Arrays to their respected Structures */
 const applyToClass = (structure, props) => {
   for (const prop of props) {
     Object.defineProperty(structure.prototype, prop, Object.getOwnPropertyDescriptor(Extendables.prototype, prop));
@@ -57,7 +96,7 @@ const applyToClass = (structure, props) => {
 applyToClass(GroupDMChannel, ["embedable", "postable", "attachable", "readable"]);
 applyToClass(DMChannel, ["embedable", "postable", "attachable", "readable"]);
 applyToClass(TextChannel, ["embedable", "postable", "attachable", "readable"]);
-applyToClass(Message, ["guildConf", "reactable"]);
+applyToClass(Message, ["guildConf", "reactable", "createCollector", "awaitReactions"]);
 applyToClass(GuildMember, ["permLevel"]);
 applyToClass(Guild, ["conf"]);
 applyToClass(User, ["permLevel"]);

--- a/utils/ReactionCollector.js
+++ b/utils/ReactionCollector.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-underscore-dangle, no-use-before-define */
+const EventEmitter = require("events").EventEmitter;
+const Collection = require("discord.js").Collection;
+
+class ReactionCollector extends EventEmitter {
+  constructor(message, filter, options = {}) {
+    super();
+
+    this.message = message;
+    this.filter = filter;
+    this.options = options;
+    this.ended = false;
+    this.collected = new Collection();
+    this.listener = reaction => this.verify(reaction);
+    this.message.client.on("messageReactionAdd", this.listener);
+    if (options.time) this.message.client.setTimeout(() => this.stop("time"), options.time);
+  }
+
+  verify(reaction) {
+    if (this.message ? this.message.id !== reaction.message.id : false) return false;
+    if (this.filter(reaction, this)) {
+      this.collected.set(reaction._emoji.name, reaction);
+      this.emit("messageReactionAdd", reaction, this);
+      if (this.collected.size >= this.options.maxMatches) this.stop("matchesLimit");
+      else if (this.options.max && this.collected.size === this.options.max) this.stop("limit");
+      return true;
+    }
+    return false;
+  }
+
+  get next() {
+    return new Promise((resolve, reject) => {
+      if (this.ended) {
+        reject(this.collected);
+        return;
+      }
+
+      const cleanup = () => {
+        this.removeListener("message", onMessage);
+        this.removeListener("end", onEnd);
+      };
+
+      const onMessage = (...args) => {
+        cleanup();
+        resolve(...args);
+      };
+
+      const onEnd = (...args) => {
+        cleanup();
+        reject(...args);
+      };
+
+      this.once("message", onMessage);
+      this.once("end", onEnd);
+    });
+  }
+
+  stop(reason = "user") {
+    if (this.ended) return;
+    this.ended = true;
+    this.message.client.removeListener("message", this.listener);
+    this.emit("end", this.collected, reason);
+  }
+}
+
+module.exports = ReactionCollector;

--- a/utils/ReactionCollector.js
+++ b/utils/ReactionCollector.js
@@ -21,6 +21,7 @@ class ReactionCollector extends EventEmitter {
     if (this.filter(reaction, this)) {
       this.collected.set(reaction._emoji.name, reaction);
       this.emit("messageReactionAdd", reaction, this);
+      if (reaction.count >= this.options.maxEmojiCount) this.stop("emojiCountLimit");
       if (this.collected.size >= this.options.maxMatches) this.stop("matchesLimit");
       else if (this.options.max && this.collected.size === this.options.max) this.stop("limit");
       return true;


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Usage fixes (Command Prompts && Floats usage type)
- Added <Message>.reactable
- Soon: ReactionCollector for messages (and awaitReactions)

Edit:
Reaction Collector added, along with <Message>awaitReactions && <Message>.createCollector
Additionally, both of these take an extra option: `maxEmojiCount` to stop the Collector once one of the reaction counts gets to that number.

This small piece of code will await for pushpins on the message sent for 10 seconds and return the amount of times users reacted pushpin to the message.
Usage:

```
const filter = (reaction) => reaction._emoji.name === "📌";

exports.run = async (client, msg) => {
const message = await msg.channel.sendMessage("This is a test reaction message");
const collection = await message.awaitReactions(filter, { time: 10000 });
message.edit(\`Collected ${collection.first().count} pins.\`);
}:

```