### PR TITLE
[Hotfix] client.funcs.log is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
+- "`client.funcs.log` is not a function" when something was wrong at startup (events not working or faulty configurations).
 - Fixed HandleCommand not passing Arguments to awaitMessage properly.
 - Fixed AwaitMessage - Kyra
 - Fixed Float Usage not correctly determining if NaN (finally)

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const loadProviders = require("./utils/loadProviders.js");
 const loadCommands = require("./utils/loadCommands.js");
 const loadCommandInhibitors = require("./utils/loadCommandInhibitors.js");
 const loadMessageMonitors = require("./utils/loadMessageMonitors.js");
+const log = require("./functions/log.js");
 
 const Config = require("./classes/Config.js");
 
@@ -56,9 +57,9 @@ exports.start = async (config) => {
     client.ready = true;
   });
 
-  client.on("error", e => client.funcs.log(e, "error"));
-  client.on("warn", w => client.funcs.log(w, "warn"));
-  client.on("disconnect", e => client.funcs.log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
+  client.on("error", e => log(e, "error"));
+  client.on("warn", w => log(w, "warn"));
+  client.on("disconnect", e => log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
 
   client.on("message", async (msg) => {
     if (!client.ready) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [PATCH]

### (If Applicable) What Issue does it fix?
Now, if something is wrong because there's a SyntaxError (or any kind of error), faulty configurations (or packages, since `uws` is not longer working), it'll use the function log with a dedicated require, since it's the only way to have it loaded from startup.

### Suggestion
I'd like to use a part from this function as an util, since it's one of the most important functions, and the only one that should be loaded before any kind of piece, but dedicated for error catching, and leaving the function log as it's right now so users can still use it.