### PR TITLE
Re-connect if Disconnection Code is 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extendables Added (postable, attachable, embedable, etc.)
 
 ### Changed
+- Komada will re-connect after CloseEvent code 1000.
 - Usage now gets the prefix from parseCommand, to reduce errors when using commands and escaped prefixes.
 - [Cache optimization] After a piece is reloaded, the cache from the `require` gets deleted.
 - [Cache optimization] After a piece is loaded inside the collection, the cache from the `require` gets deleted.

--- a/app.js
+++ b/app.js
@@ -59,7 +59,10 @@ exports.start = async (config) => {
 
   client.on("error", e => log(e, "error"));
   client.on("warn", w => log(w, "warn"));
-  client.on("disconnect", e => log(`Disconnected | ${e.code}: ${e.reason}`, "error"));
+  client.on("disconnect", (e) => {
+    log(`Disconnected | ${e.code}: ${e.reason}`, "error");
+    if (e.code === 1000) client.login(client.config.botToken);
+  });
 
   client.on("message", async (msg) => {
     if (!client.ready) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.18.14",
+  "version": "0.18.15",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "app.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

Auto-reconnect if the event closed with error 1000
```
CLOSE_NORMAL (1000) >Normal closure; the connection successfully completed whatever purpose for which it was created.
From: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
```