### PR TITLE
[FEATURE] Compiled Language Support

### DIFF
--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -1,8 +1,10 @@
+const fs = require("fs");
 const path = require("path");
 
 module.exports = (client, command, reload = false, loadPath = null) => new Promise(async (resolve, reject) => {
   let category;
   let subCategory;
+  let codeLang;
   let cmd;
   if (!loadPath && !reload) return reject("Path must be provided when loading a new command.");
   if (reload) {
@@ -38,6 +40,10 @@ module.exports = (client, command, reload = false, loadPath = null) => new Promi
       pathParts = pathParts.slice(pathParts.indexOf("commands") + 1);
       category = client.funcs.toTitleCase(cmd.help.category ? cmd.help.category : (pathParts[0] && pathParts[0].length > 0 && pathParts[0].indexOf(".") === -1 ? pathParts[0] : "General"));
       subCategory = client.funcs.toTitleCase(cmd.help.subCategory ? cmd.help.subCategory : (pathParts[1] && pathParts[1].length > 0 && pathParts[1].indexOf(".") === -1 ? pathParts[1] : "General"));
+      // Remove the ".js" extension, if there is one, since it's optional.
+      const cljsPath = `${loadPath.replace(/\.js$/, "")}.cljs`;
+      // If there is an equivalent file ending with ".cljs", it's compiled CLJS.
+      codeLang = fs.existsSync(cljsPath) ? "CLJS" : "JS";
     } catch (e) {
       if (e.code === "MODULE_NOT_FOUND") {
         const module = /'[^']+'/g.exec(e.toString());
@@ -57,6 +63,7 @@ module.exports = (client, command, reload = false, loadPath = null) => new Promi
   cmd.help.category = category;
   cmd.help.subCategory = subCategory;
   cmd.help.filePath = loadPath;
+  cmd.help.codeLang = codeLang;
 
     // Load Aliases
   cmd.conf.aliases.forEach((alias) => {

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -4,9 +4,14 @@ const path = require("path");
 module.exports = (client, command, reload = false, loadPath = null) => new Promise(async (resolve, reject) => {
   let category;
   let subCategory;
-  const compiledLangs = Array.isArray(client.config.compiledLang) ?
-    client.config.compiledLang :
-    [client.config.compiledLang];
+  let compiledLangs = [];
+  if (client.config.compiledLang) {
+    if (Array.isArray(client.config.compiledLang)) {
+      compiledLangs = client.config.compiledLang;
+    } else {
+      compiledLangs = [client.config.compiledLang];
+    }
+  }
   let codeLang;
   let cmd;
   if (!loadPath && !reload) return reject("Path must be provided when loading a new command.");

--- a/functions/loadSingleCommand.js
+++ b/functions/loadSingleCommand.js
@@ -4,9 +4,9 @@ const path = require("path");
 module.exports = (client, command, reload = false, loadPath = null) => new Promise(async (resolve, reject) => {
   let category;
   let subCategory;
-  const compiledLangs = typeof client.config.compiledLangs === "string" ?
-    [client.config.compiledLangs] :
-    client.config.compiledLangs;
+  const compiledLangs = Array.isArray(client.config.compiledLang) ?
+    client.config.compiledLang :
+    [client.config.compiledLang];
   let codeLang;
   let cmd;
   if (!loadPath && !reload) return reject("Path must be provided when loading a new command.");

--- a/utils/loadCommands.js
+++ b/utils/loadCommands.js
@@ -48,7 +48,7 @@ module.exports = async (client) => {
     langCounts[lang]++;
   });
   let countMsg = "";
-  if (langCounts.length >= 2) {
+  if (Object.keys(langCounts).length >= 2) {
     countMsg = ` (${Object.entries(langCounts).sort(([lang1], [lang2]) => {
       // JS should appear first
       if (lang1 === "JS") return -1;

--- a/utils/loadCommands.js
+++ b/utils/loadCommands.js
@@ -40,7 +40,24 @@ module.exports = async (client) => {
       client.outBaseDir !== client.clientBaseDir) {
     await loadCommands(client, client.outBaseDir).catch(err => client.emit("error", client.funcs.newError(err)));
   }
-  const countJS = client.commands.filter(c => c.help.codeLang === "JS").size;
-  const countCLJS = client.commands.filter(c => c.help.codeLang === "CLJS").size;
-  client.funcs.log(`Loaded ${client.commands.size} commands (${countJS} JS, ${countCLJS} CLJS), with ${client.aliases.size} aliases.`);
+
+  const langCounts = [];
+  client.commands.forEach((c) => {
+    const lang = c.help.codeLang;
+    langCounts[lang] = langCounts[lang] || 0;
+    langCounts[lang]++;
+  });
+  let countMsg = "";
+  if (langCounts.length >= 2) {
+    countMsg = ` (${Object.entries(langCounts).sort(([lang1], [lang2]) => {
+      // JS should appear first
+      if (lang1 === "JS") return -1;
+      if (lang2 === "JS") return 1;
+      // Otherwise sort based on the default comparison order
+      if (lang1 === lang2) return 0;
+      if ([lang1, lang2].sort()[0] === lang1) return -1;
+      return 1;
+    }).map(([lang, count]) => `${count} ${lang}`).join(", ")})`;
+  }
+  client.funcs.log(`Loaded ${client.commands.size} commands${countMsg}, with ${client.aliases.size} aliases.`);
 };

--- a/utils/loadCommands.js
+++ b/utils/loadCommands.js
@@ -25,11 +25,22 @@ const loadCommands = (client, baseDir) => new Promise(async (resolve, reject) =>
 });
 
 module.exports = async (client) => {
+  // The base directory of code compiled into JS.
+  client.outBaseDir = client.config.outBaseDir;
+
   client.commands.clear();
   client.aliases.clear();
   await loadCommands(client, client.clientBaseDir).catch(err => client.emit("error", client.funcs.newError(err)));
   if (client.coreBaseDir !== client.clientBaseDir) {
     await loadCommands(client, client.coreBaseDir).catch(err => client.emit("error", client.funcs.newError(err)));
   }
-  client.funcs.log(`Loaded ${client.commands.size} commands, with ${client.aliases.size} aliases.`);
+  // Load from out dir if different from core and client dirs.
+  if (client.outBaseDir &&
+      client.outBaseDir !== client.coreBaseDir &&
+      client.outBaseDir !== client.clientBaseDir) {
+    await loadCommands(client, client.outBaseDir).catch(err => client.emit("error", client.funcs.newError(err)));
+  }
+  const countJS = client.commands.filter(c => c.help.codeLang === "JS").size;
+  const countCLJS = client.commands.filter(c => c.help.codeLang === "CLJS").size;
+  client.funcs.log(`Loaded ${client.commands.size} commands (${countJS} JS, ${countCLJS} CLJS), with ${client.aliases.size} aliases.`);
 };


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
MINOR
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- New Komada.start option: "compiledLang" (can be string or array)
  - The language(s) used, that compile to JS
- For every command loaded, detects if there's a version with the compiledLang's extension (if any compiledLang was specified), saving the language in `help.codeLang`
- Modifies the "Loaded X commands, with Y aliases." log message to show a count of each language
- New Komada.start option: "outBaseDir"
  - The directory where the compiled language(s) is compiled to
  - Commands, events, etc. are loaded from this directory, if present, in addition to client and core dirs
  - (This should maybe be changed to an environment var, to match clientDir)

These changes make Komada more flexible for people who use languages that compile to JavaScript, like ClojureScript or Coffee.