### PR TITLE
Fix unexpected behavior with runIn inhibitor

### DIFF
--- a/inhibitors/runIn.js
+++ b/inhibitors/runIn.js
@@ -5,10 +5,7 @@ exports.conf = {
 };
 
 exports.run = (client, msg, cmd) => {
-  if (!cmd.conf.runIn) {
-    cmd.conf.runIn = ["text"];
-    return false;
-  }
+  if (!cmd.conf.runIn) cmd.conf.runIn = ["text"];
   if (cmd.conf.runIn.includes(msg.channel.type)) return false;
   return `This command is only avaliable in ${cmd.conf.runIn.join(" ")} channels`;
 };


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
PATCH
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixes runIn Inhibitor
-
-


### (If Applicable) What Issue does it fix?
 Fixes...  if I run a command in dm's the first time it is run, and cmd.conf.runIn isn't defined, it gets defined as guildOnly, but then runs it in the dm anyway... This corrects that behavior, to only run in a guild if runIn isn't defined
