### PR TITLE
Prepare Komada for new Discord.js release

### DIFF
--- a/classes/Extendables.js
+++ b/classes/Extendables.js
@@ -18,22 +18,22 @@ class Extendables {
     */
   get readable() {
     if (!this.guild) return true;
-    return this.permissionsFor(this.guild.member(this.client.user)).hasPermission("READ_MESSAGES");
+    return this.permissionsFor(this.guild.member(this.client.user)).has("READ_MESSAGES");
   }
 
   get embedable() {
     if (!this.guild) return true;
-    return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("EMBED_LINKS");
+    return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).has("EMBED_LINKS");
   }
 
   get postable() {
     if (!this.guild) return true;
-    return this.readable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("SEND_MESSAGES");
+    return this.readable && this.permissionsFor(this.guild.member(this.client.user)).has("SEND_MESSAGES");
   }
 
   get attachable() {
     if (!this.guild) return true;
-    return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ATTACH_FILES");
+    return this.readable && this.postable && this.permissionsFor(this.guild.member(this.client.user)).has("ATTACH_FILES");
   }
 
   /** Message Extendables - Apply to all messages
@@ -45,7 +45,7 @@ class Extendables {
     */
   get reactable() {
     if (!this.guild) return true;
-    return this.readable && this.permissionsFor(this.guild.member(this.client.user)).hasPermission("ADD_REACTIONS");
+    return this.readable && this.permissionsFor(this.guild.member(this.client.user)).has("ADD_REACTIONS");
   }
 
   hasAtleastPermissionLevel(min) {

--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -59,7 +59,7 @@ exports.run = async (client, msg, [link, piece, folder = "Downloaded"]) => {
 
   const collector = msg.channel.createMessageCollector(mes => mes.author === msg.author, { time: 20000 });
 
-  collector.on("message", (mes) => {
+  collector.on("collect", (mes) => {
     if (mes.content.toLowerCase() === "no") collector.stop("aborted");
     if (mes.content.toLowerCase() === "yes") collector.stop("success");
   });

--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -57,7 +57,7 @@ exports.run = async (client, msg, [link, piece, folder = "Downloaded"]) => {
     "```"];
   msg.sendMessage(`Are you sure you want to load the following ${type} into your bot? This will also install all required modules. This prompt will abort after 20 seconds.${code.join("\n")}`);
 
-  const collector = msg.channel.createCollector(mes => mes.author === msg.author, { time: 20000 });
+  const collector = msg.channel.createMessageCollector(mes => mes.author === msg.author, { time: 20000 });
 
   collector.on("message", (mes) => {
     if (mes.content.toLowerCase() === "no") collector.stop("aborted");

--- a/events/message.js
+++ b/events/message.js
@@ -79,7 +79,7 @@ exports.runCommand = (client, msg, start) => {
 
 /* eslint-disable no-throw-literal */
 exports.awaitMessage = async (client, msg, start, error) => {
-  const message = await msg.channel.sendMessage(`<@!${msg.member.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`)
+  const message = await msg.channel.send(`<@!${msg.member.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`)
     .catch((err) => { throw client.funcs.newError(err); });
 
   const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, { max: 1, time: 30000, errors: ["time"] });


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)
- Switch from `TextBasedChannel#createCollector` to `TextBasedChannel#createMessageCollector` as the former as now deprecated within discord.js 
- Switch from `TextBasedChannel#sendMessage` to `TextBasedChannel#send` in `events/message.js` (line 82) as the former is now deprecated within discord.js
- Switch from `collector.on('message')` to `collector.on('collect')` as the former is now deprecated within discord.js because of the new types of collector
- Replace multiple occurences of `EvaluatedPermissions#hasPermission` with `EvaluatedPermissions#has` as the former is now deprecated within discord.js

### (If Applicable) What issue does it fix?
Discord.js will soon be releasing a new version, and users of Komada may see deprecation warnings if they update discord.js. This PR updates Komada so that it is using the new, preferred methods over the deprecated ones.
