### PR TITLE
Fix Ao's silly mistake

### DIFF
--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -16,7 +16,7 @@ exports.run = async (client, msg, [type, name]) => {
   const isCommand = type === "command" ? "System/" : "";
   fs.copyAsync(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
     .then(() => {
-      reload[type].call(client.funcs, `${isCommand}${name}`).catch(response => { throw `❌ ${response}`; });
+      reload[type].call(client.funcs, `${isCommand}${name}`).catch((response) => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);
     })
     .catch((err) => {

--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -16,7 +16,7 @@ exports.run = async (client, msg, [type, name]) => {
   const isCommand = type === "command" ? "System/" : "";
   fs.copyAsync(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
     .then(() => {
-      reload[type].call(client.funcs, `System/${name}`).catch(response => { throw `❌ ${response}`; });
+      reload[type].call(client.funcs, `${isCommand}${name}`).catch(response => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);
     })
     .catch((err) => {

--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -16,7 +16,7 @@ exports.run = async (client, msg, [type, name]) => {
   const isCommand = type === "command" ? "System/" : "";
   fs.copyAsync(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
     .then(() => {
-      reload[type](`System/${name}`).catch((response) => { throw `❌ ${response}`; });
+			reload[type].call(client.funcs, `System/${name}`).catch(response => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);
     })
     .catch((err) => {

--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -16,7 +16,7 @@ exports.run = async (client, msg, [type, name]) => {
   const isCommand = type === "command" ? "System/" : "";
   fs.copyAsync(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
     .then(() => {
-			reload[type].call(client.funcs, `System/${name}`).catch(response => { throw `❌ ${response}`; });
+      reload[type].call(client.funcs, `System/${name}`).catch(response => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);
     })
     .catch((err) => {


### PR DESCRIPTION
Pushing the funcs into an object rebound the this to that object. using .call() we can rebind this to what it should have been in the first place (client.funcs)

### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
None
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change transfer to use .call()
-
-


### (If Applicable) What Issue does it fix?
Fixes transfer not properly reloading