### PR TITLE
Feature: disable core functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - Classbased | Staged for 0.20.0
 ### Added
+- Added option to disable core functions. Now you can skip load of core functions instead of override it.
 - Command Editing is now possible via setting config.cmdEditing to true. You will need to make a few changes to your code to make it work though:
 - A new messageUpdate core event.
 - New methods attached to the Discord.js message object to enable command editing: message.send, message.sendMessage, message.sendCode, message.sendEmbed. These methods will cache the command message and the response message, and edit the response message if the command message is found in the cache.

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -33,9 +33,10 @@ module.exports = class Loader {
   }
 
   async loadFunctions() {
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.functions.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
@@ -76,23 +77,26 @@ module.exports = class Loader {
   }
 
   async walkCommandDirectories(dir) {
-    const files = await fs.readdirAsync(dir)
+    let files = await fs.readdirAsync(dir)
       .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
+    files = files.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
     await this.loadFiles(files.filter(file => file.endsWith(".js")), dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];
     const mps1 = files.filter(file => !file.includes(".")).map(async (folder) => {
-      const subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
+      let subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
+      subFiles = subFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subFiles.filter(file => file.endsWith(".js")).map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
     await Promise.all(mps1).catch((err) => { throw err; });
     const mps2 = subfolders.map(async (subfolder) => {
-      const subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
+      let subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
+      subSubFiles = subSubFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")).map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -142,9 +146,10 @@ module.exports = class Loader {
 
   async loadCommandInhibitors() {
     this.client.commandInhibitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
@@ -181,9 +186,10 @@ module.exports = class Loader {
 
   async loadCommandFinalizers() {
     this.client.commandFinalizers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
@@ -215,9 +221,10 @@ module.exports = class Loader {
   async loadEvents() {
     this.client.eventHandlers.forEach((listener, event) => this.client.removeListener(event, listener));
     this.client.eventHandlers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.events.includes(file.split(".")[0]));      
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
@@ -251,9 +258,10 @@ module.exports = class Loader {
 
   async loadMessageMonitors() {
     this.client.messageMonitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.monitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
@@ -284,9 +292,10 @@ module.exports = class Loader {
 
   async loadProviders() {
     this.client.providers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.providers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }

--- a/client.js
+++ b/client.js
@@ -16,6 +16,16 @@ module.exports = class Komada extends Discord.Client {
     if (typeof config !== "object") throw new TypeError("Configuration for Komada must be an object.");
     super(config.clientOptions);
     this.config = config;
+    this.config.disabled = config.disabled || {};
+    this.config.disabled = {
+      commands: config.disabled.commands || [],
+      events: config.disabled.events || [],
+      functions: config.disabled.functions || [],
+      inhibitors: config.disabled.inhibitors || [],
+      finalizers: config.disabled.finalizers || [],
+      monitors: config.disabled.monitors || [],
+      providers: config.disabled.providers || []
+    };    
     this.funcs = new Loader(this);
     this.argResolver = new ArgResolver(this);
     this.helpStructure = new Map();


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- [x] Added option to disable core functions. Now you can skip load of core functions instead of override it.
example of use:
```js
const Komada = require('komada');
const client = new Komada({
  "ownerID" : "your-user-id",
  "clientID": "the-invite-app-id",
  "prefix": "+",
  "clientOptions": {
    "fetchAllMembers": true
  },
  "disabled": {
    "commands": ['eval', 'reboot', 'transfer'],
    "events": ['messageBulkDelete'],
    "functions": ['regExpEsc'],
    "inhibitors": ['commandCooldown'],
    "finalizers": ['commandCooldown'],
    "monitors": [],
    "providers": []
  }  
});
```

### (If Applicable) What Issue does it fix?
It should fix wrong ways to override core functions.
