### PR TITLE
Feature: disable core functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - Classbased | Staged for 0.20.0
 ### Added
+- Added option to disable core functions. Now you can skip load of core functions instead of override it.
 - Command Editing is now possible via setting config.cmdEditing to true. You will need to make a few changes to your code to make it work though:
 - A new messageUpdate core event.
 - New methods attached to the Discord.js message object to enable command editing: message.send, message.sendMessage, message.sendCode, message.sendEmbed. These methods will cache the command message and the response message, and edit the response message if the command message is found in the cache.

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -6,9 +6,9 @@ const ParsedUsage = require("./parsedUsage");
 
 const coreProtected = {
   commands: [],
-  events: [],
-  functions: [],
-  inhibitors: [],
+  events: ["disconnect", "error", "guildCreate", "guildDelete", "log", "message", "messageBulkDelete", "messageDelete", "messageUpdate", "warn"],
+  functions: ["checkPerms", "clean", "confs", "getPrefix", "handleError", "newError", " regExpEsc", "toTitleCase"],
+  inhibitors: ["runIn", "disable", "permissions", "requiredFuncs", "missingBotPermissions", "disable"],
   finalizers: [],
   monitors: [],
   providers: [],

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -4,13 +4,15 @@ const { sep } = require("path");
 
 const ParsedUsage = require("./parsedUsage");
 
-const protectedFunctions = [];
-const protectedCommands = [];
-const protectedInhibitors = [];
-const protectedFinalizers = [];
-const protectedEvents = [];
-const protectedMonitors = [];
-const protectedProviders = [];
+const coreProtected = {
+  commands: [],
+  events: [],
+  functions: [],
+  inhibitors: [],
+  finalizers: [],
+  monitors: [],
+  providers: [],
+};
 
 /* eslint-disable no-throw-literal, import/no-dynamic-require, class-methods-use-this */
 module.exports = class Loader {
@@ -44,7 +46,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedFunctions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.functions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
@@ -88,7 +90,7 @@ module.exports = class Loader {
     let files = await fs.readdirAsync(dir)
       .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
-    files = files.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
+    files = files.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
     await this.loadFiles(files.filter(file => file.endsWith(".js")), dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];
@@ -96,7 +98,7 @@ module.exports = class Loader {
       let subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
-      subFiles = subFiles.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
+      subFiles = subFiles.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subFiles.filter(file => file.endsWith(".js")).map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -104,7 +106,7 @@ module.exports = class Loader {
     const mps2 = subfolders.map(async (subfolder) => {
       let subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
-      subSubFiles = subSubFiles.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
+      subSubFiles = subSubFiles.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")).map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -157,7 +159,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedInhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.inhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
@@ -197,7 +199,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedFinalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.finalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
@@ -232,7 +234,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedEvents.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.events.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
@@ -269,7 +271,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedMonitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.monitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
@@ -303,7 +305,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => protectedProviders.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => coreProtected.providers.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -224,7 +224,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.events.includes(file.split(".")[0]));      
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.events.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -43,11 +43,12 @@ module.exports = class Loader {
   }
 
   async loadFunctions() {
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.functions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.functions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}functions${sep}`)
@@ -87,27 +88,30 @@ module.exports = class Loader {
   }
 
   async walkCommandDirectories(dir) {
-    let files = await fs.readdirAsync(dir)
+    const files = await fs.readdirAsync(dir)
       .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
-    files = files.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
-    await this.loadFiles(files.filter(file => file.endsWith(".js")), dir, this.loadNewCommand, this.loadCommands)
+    await this.loadFiles(files.filter(file => file.endsWith(".js")
+      && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
+      , dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];
     const mps1 = files.filter(file => !file.includes(".")).map(async (folder) => {
-      let subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
+      const subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
-      subFiles = subFiles.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
-      return this.loadFiles(subFiles.filter(file => file.endsWith(".js")).map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
+      return this.loadFiles(subFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
+        .map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
     await Promise.all(mps1).catch((err) => { throw err; });
     const mps2 = subfolders.map(async (subfolder) => {
-      let subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
+      const subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
-      subSubFiles = subSubFiles.filter(file => coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
-      return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")).map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
+      return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
+        .map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
     return Promise.all(mps2).catch((err) => { throw err; });
@@ -156,11 +160,12 @@ module.exports = class Loader {
 
   async loadCommandInhibitors() {
     this.client.commandInhibitors.clear();
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.inhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.inhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}inhibitors${sep}`)
@@ -196,11 +201,12 @@ module.exports = class Loader {
 
   async loadCommandFinalizers() {
     this.client.commandFinalizers.clear();
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.finalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.finalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}finalizers${sep}`)
@@ -231,11 +237,12 @@ module.exports = class Loader {
   async loadEvents() {
     this.client.eventHandlers.forEach((listener, event) => this.client.removeListener(event, listener));
     this.client.eventHandlers.clear();
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.events.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.events.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}events${sep}`)
@@ -268,11 +275,12 @@ module.exports = class Loader {
 
   async loadMessageMonitors() {
     this.client.messageMonitors.clear();
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.monitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.monitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}monitors${sep}`)
@@ -302,11 +310,12 @@ module.exports = class Loader {
 
   async loadProviders() {
     this.client.providers.clear();
-    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
+    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => coreProtected.providers.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0]));
-      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
+      await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
+        && (coreProtected.providers.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0])))
+        , this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}providers${sep}`)

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -33,9 +33,10 @@ module.exports = class Loader {
   }
 
   async loadFunctions() {
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.functions.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
@@ -76,23 +77,26 @@ module.exports = class Loader {
   }
 
   async walkCommandDirectories(dir) {
-    const files = await fs.readdirAsync(dir)
+    let files = await fs.readdirAsync(dir)
       .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
+    files = files.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
     await this.loadFiles(files.filter(file => file.endsWith(".js")), dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];
     const mps1 = files.filter(file => !file.includes(".")).map(async (folder) => {
-      const subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
+      let subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
+      subFiles = subFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subFiles.filter(file => file.endsWith(".js")).map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
     await Promise.all(mps1).catch((err) => { throw err; });
     const mps2 = subfolders.map(async (subfolder) => {
-      const subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
+      let subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
+      subSubFiles = subSubFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")).map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -142,9 +146,10 @@ module.exports = class Loader {
 
   async loadCommandInhibitors() {
     this.client.commandInhibitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
@@ -181,9 +186,10 @@ module.exports = class Loader {
 
   async loadCommandFinalizers() {
     this.client.commandFinalizers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
@@ -215,9 +221,10 @@ module.exports = class Loader {
   async loadEvents() {
     this.client.eventHandlers.forEach((listener, event) => this.client.removeListener(event, listener));
     this.client.eventHandlers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.events.includes(file.split(".")[0]));      
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
@@ -251,9 +258,10 @@ module.exports = class Loader {
 
   async loadMessageMonitors() {
     this.client.messageMonitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.monitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
@@ -284,9 +292,10 @@ module.exports = class Loader {
 
   async loadProviders() {
     this.client.providers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
+    let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
+      coreFiles = coreFiles.filter(file => !this.client.config.disabled.providers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -4,6 +4,14 @@ const { sep } = require("path");
 
 const ParsedUsage = require("./parsedUsage");
 
+const protectedFunctions = [];
+const protectedCommands = [];
+const protectedInhibitors = [];
+const protectedFinalizers = [];
+const protectedEvents = [];
+const protectedMonitors = [];
+const protectedProviders = [];
+
 /* eslint-disable no-throw-literal, import/no-dynamic-require, class-methods-use-this */
 module.exports = class Loader {
   constructor(client) {
@@ -36,7 +44,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.functions.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedFunctions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
@@ -80,7 +88,7 @@ module.exports = class Loader {
     let files = await fs.readdirAsync(dir)
       .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
-    files = files.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
+    files = files.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
     await this.loadFiles(files.filter(file => file.endsWith(".js")), dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];
@@ -88,7 +96,7 @@ module.exports = class Loader {
       let subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
-      subFiles = subFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
+      subFiles = subFiles.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subFiles.filter(file => file.endsWith(".js")).map(file => `${folder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -96,7 +104,7 @@ module.exports = class Loader {
     const mps2 = subfolders.map(async (subfolder) => {
       let subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
-      subSubFiles = subSubFiles.filter(file => !this.client.config.disabled.commands.includes(file.split(".")[0]));
+      subSubFiles = subSubFiles.filter(file => protectedCommands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0]));
       return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")).map(file => `${subfolder.folder}${sep}${subfolder.subfolder}${sep}${file}`), dir, this.loadNewCommand, this.loadCommands)
         .catch((err) => { throw err; });
     });
@@ -149,7 +157,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedInhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
@@ -189,7 +197,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedFinalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
@@ -224,7 +232,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.events.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedEvents.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
@@ -261,7 +269,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.monitors.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedMonitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
@@ -295,7 +303,7 @@ module.exports = class Loader {
     let coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
       .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
-      coreFiles = coreFiles.filter(file => !this.client.config.disabled.providers.includes(file.split(".")[0]));
+      coreFiles = coreFiles.filter(file => protectedProviders.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0]));
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")), this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }

--- a/client.js
+++ b/client.js
@@ -16,6 +16,16 @@ module.exports = class Komada extends Discord.Client {
     if (typeof config !== "object") throw new TypeError("Configuration for Komada must be an object.");
     super(config.clientOptions);
     this.config = config;
+    this.config.disabled = config.disabled || {};
+    this.config.disabled = {
+      commands: config.disabled.commands || [],
+      events: config.disabled.events || [],
+      functions: config.disabled.functions || [],
+      inhibitors: config.disabled.inhibitors || [],
+      finalizers: config.disabled.finalizers || [],
+      monitors: config.disabled.monitors || [],
+      providers: config.disabled.providers || []
+    };    
     this.funcs = new Loader(this);
     this.argResolver = new ArgResolver(this);
     this.helpStructure = new Map();

--- a/client.js
+++ b/client.js
@@ -24,8 +24,8 @@ module.exports = class Komada extends Discord.Client {
       inhibitors: config.disabled.inhibitors || [],
       finalizers: config.disabled.finalizers || [],
       monitors: config.disabled.monitors || [],
-      providers: config.disabled.providers || []
-    };    
+      providers: config.disabled.providers || [],
+    };
     this.funcs = new Loader(this);
     this.argResolver = new ArgResolver(this);
     this.helpStructure = new Map();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "main": "client.js",


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- [x] Added option to disable core functions. Now you can skip load of core functions instead of override it.
example of use:
```js
const Komada = require('komada');
const client = new Komada({
  "ownerID" : "your-user-id",
  "clientID": "the-invite-app-id",
  "prefix": "+",
  "clientOptions": {
    "fetchAllMembers": true
  },
  "disabled": {
    "commands": ['eval', 'reboot', 'transfer'],
    "events": ['messageBulkDelete'],
    "functions": ['regExpEsc'],
    "inhibitors": ['commandCooldown'],
    "finalizers": ['commandCooldown'],
    "monitors": [],
    "providers": []
  }  
});
```

### (If Applicable) What Issue does it fix?
It should fix wrong ways to override core functions.
