### PR TITLE
Add helper Classes/ PermLevel helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added a timer to the loading.
 - Finalizers: Functions which are run on after a successful command. *Please Note: All command files must be defined as async. `exports.run = __async__ (client, msg, ...`*
 - Command Cooldowns are now available through a new inhibitor/finalizer combo. Simply set command.conf.cooldown to an integer in seconds to put a cooldown on that command.
+- A helper class for generating permission levels. It can be accessed via require('komada').PermLevels, and is used via permlevels.addLevel(level, break, checkFunction). Once you have all levels added, simply pass permlevels.structure to your client.config as the "permStructure" property.
 
 ### Changed
 - Changed fetchMessages to fetchMessage (backend change)
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Minimum node version is now v7.6.x
 - Remaining Utils have been moved to the classes folder.
 - Use Discord.Permissions to generate and keep cached an implied permissions object, instead of generating a new object every time a command is run.
+- client.config.selfbot config is no longer needed for selfbot mode. Komada now detects if it is being run as a user, and takes all selbot precautions.
 
 ### Fixed
 -

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ client.login("your-bot-token");
 - **prefix**: The default prefix when the bot first boots up. This option becomes useless after first boot, since the prefix is written to the default configuration system.
 - **clientOptions**: These are passed directly to the discord.js library. They are optional. For more information on which options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions).
 
-> For all you selfbot users out there, you can add a option ('selfbot': true) to have Komada enabled for selfbot usage. i.e. only respond to commands from you.
+> Komada automatically detects selfbot mode, and takes appropriate percautions, such as not responding to anyone but yourself.
 
 ## Running the bot
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ npm install --save komada
 Create a file called `app.js` (or whatever you prefer) which will initiate and configure Komada.
 
 ```js
-const Komada = require('komada');
-const client = new Komada({
+const komada = require('komada');
+const client = new komada.Client({
   "ownerID" : "your-user-id",
   "clientID": "the-invite-app-id",
   "prefix": "+",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ client.login("your-bot-token");
 - **prefix**: The default prefix when the bot first boots up. This option becomes useless after first boot, since the prefix is written to the default configuration system.
 - **clientOptions**: These are passed directly to the discord.js library. They are optional. For more information on which options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions).
 
-> Komada automatically detects selfbot mode, and takes appropriate percautions, such as not responding to anyone but yourself.
+> Komada automatically detects selfbot mode, and takes appropriate precautions, such as not responding to anyone but yourself.
 
 ## Running the bot
 

--- a/classes/client.js
+++ b/classes/client.js
@@ -13,18 +13,18 @@ require("./Extendables.js");
 const defaultPermStructure = new PermLevels()
   .addLevel(0, false, () => true)
   .addLevel(2, false, (client, msg) => {
-      if (!msg.guild) return false;
-      const modRole = msg.guild.roles.find("name", msg.guild.conf.modRole);
-      return modRole && msg.member.roles.has(modRole.id);
+    if (!msg.guild) return false;
+    const modRole = msg.guild.roles.find("name", msg.guild.conf.modRole);
+    return modRole && msg.member.roles.has(modRole.id);
   })
   .addLevel(3, false, (client, msg) => {
-      if (!msg.guild) return false;
-      const adminRole = msg.guild.roles.find("name", msg.guild.conf.adminRole);
-      return adminRole && msg.member.roles.has(adminRole.id);
+    if (!msg.guild) return false;
+    const adminRole = msg.guild.roles.find("name", msg.guild.conf.adminRole);
+    return adminRole && msg.member.roles.has(adminRole.id);
   })
   .addLevel(4, false, (client, msg) => {
-      if (!msg.guild) return false;
-      return msg.author.id === msg.guild.owner.id;
+    if (!msg.guild) return false;
+    return msg.author.id === msg.guild.owner.id;
   })
   .addLevel(9, true, (client, msg) => msg.author.id === client.config.ownerID)
   .addLevel(10, false, (client, msg) => msg.author.id === client.config.ownerID);

--- a/classes/client.js
+++ b/classes/client.js
@@ -79,7 +79,7 @@ module.exports = class Komada extends Discord.Client {
   }
 
   get invite() {
-    if (this.config.selfbot) throw "Why would you need an invite link for a selfbot...";
+    if (!this.user.bot) throw "Why would you need an invite link for a selfbot...";
     const permissions = Discord.Permissions.resolve([...new Set(this.commands.reduce((a, b) => a.concat(b.conf.botPerms), ["READ_MESSAGES", "SEND_MESSAGES"]))]);
     return `https://discordapp.com/oauth2/authorize?client_id=${this.application.id}&permissions=${permissions}&scope=bot`;
   }
@@ -103,7 +103,7 @@ module.exports = class Komada extends Discord.Client {
 
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
-    if (!this.config.selfbot) this.application = await super.fetchApplication();
+    if (this.user.bot) this.application = await super.fetchApplication();
     await Promise.all(Object.keys(this.funcs).map((key) => {
       if (this.funcs[key].init) return this.funcs[key].init(this);
       return true;

--- a/classes/permLevels.js
+++ b/classes/permLevels.js
@@ -4,9 +4,9 @@ module.exports = class PermissionLevels {
     this.levels = new Map();
   }
 
-  addLevel(level, break, check) {
+  addLevel(level, brk, chk) {
     if (this.levels.has(level)) throw new Error(`Level ${level} is already defined`);
-    this.levels.set(level, { break, check });
+    this.levels.set(level, { "break": brk, "check": chk });
     return this;
   }
 

--- a/classes/permLevels.js
+++ b/classes/permLevels.js
@@ -1,0 +1,23 @@
+module.exports = class PermissionLevels {
+
+  constructor() {
+    this.levels = new Map();
+  }
+
+  addLevel(level, break, check) {
+    if (this.levels.has(level)) throw new Error(`Level ${level} is already defined`);
+    this.levels.set(level, { break, check });
+    return this;
+  }
+
+  get structure() {
+    const structure = [];
+    for (let i = 0; i < 11; i++) {
+       const myLevel = this.levels.get(i);
+       if (myLevel) structure.push(myLevel);
+       else structure.push({break: false, check: () => false});
+    }
+    return structure;
+  }
+
+};

--- a/classes/permLevels.js
+++ b/classes/permLevels.js
@@ -15,7 +15,7 @@ module.exports = class PermissionLevels {
     for (let i = 0; i < 11; i++) {
        const myLevel = this.levels.get(i);
        if (myLevel) structure.push(myLevel);
-       else structure.push({break: false, check: () => false});
+       else structure.push({"break": false, "check": () => false});
     }
     return structure;
   }

--- a/classes/permLevels.js
+++ b/classes/permLevels.js
@@ -6,16 +6,16 @@ module.exports = class PermissionLevels {
 
   addLevel(level, brk, chk) {
     if (this.levels.has(level)) throw new Error(`Level ${level} is already defined`);
-    this.levels.set(level, { "break": brk, "check": chk });
+    this.levels.set(level, { break: brk, check: chk });
     return this;
   }
 
   get structure() {
     const structure = [];
     for (let i = 0; i < 11; i++) {
-       const myLevel = this.levels.get(i);
-       if (myLevel) structure.push(myLevel);
-       else structure.push({"break": false, "check": () => false});
+      const myLevel = this.levels.get(i);
+      if (myLevel) structure.push(myLevel);
+      else structure.push({ break: false, check: () => false });
     }
     return structure;
   }

--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -43,7 +43,7 @@ exports.run = async (client, msg, [link, piece, folder = "Downloaded"]) => {
     throw `<@!${msg.author.id}> | ${err}`;
   }
 
-  if (mod.exports.conf.selfbot && !client.config.selfbot) throw `I am not a selfbot, so I cannot download nor use ${name}.`;
+  if (mod.exports.conf.selfbot && client.user.bot) throw `I am not a selfbot, so I cannot download nor use ${name}.`;
 
   const code = ["```asciidoc",
     "=== NAME ===",

--- a/commands/System/help.js
+++ b/commands/System/help.js
@@ -1,6 +1,6 @@
 /* eslint-disable guard-for-in, no-restricted-syntax, no-prototype-builtins */
 exports.run = async (client, msg, [cmd]) => {
-  const method = !client.config.selfbot ? "author" : "channel";
+  const method = client.config.bot ? "author" : "channel";
   cmd = client.commands.get(cmd) || client.commands.get(client.aliases.get(cmd));
   if (cmd) {
     return msg[method].send([
@@ -19,7 +19,7 @@ exports.run = async (client, msg, [cmd]) => {
     helpMessage.push("```\n\u200b");
   }
   return msg[method].send(helpMessage, { split: { char: "\u200b" } }).catch(err => client.emit("error", err))
-    .then(() => { if (msg.channel.type !== "dm" && !client.config.selfbot) msg.sendMessage("Commands have been sent to your DMs."); });
+    .then(() => { if (msg.channel.type !== "dm" && client.config.bot) msg.sendMessage("Commands have been sent to your DMs."); });
 };
 
 exports.conf = {

--- a/commands/System/help.js
+++ b/commands/System/help.js
@@ -1,6 +1,6 @@
 /* eslint-disable guard-for-in, no-restricted-syntax, no-prototype-builtins */
 exports.run = async (client, msg, [cmd]) => {
-  const method = client.config.bot ? "author" : "channel";
+  const method = client.user.bot ? "author" : "channel";
   cmd = client.commands.get(cmd) || client.commands.get(client.aliases.get(cmd));
   if (cmd) {
     return msg[method].send([
@@ -19,7 +19,7 @@ exports.run = async (client, msg, [cmd]) => {
     helpMessage.push("```\n\u200b");
   }
   return msg[method].send(helpMessage, { split: { char: "\u200b" } }).catch(err => client.emit("error", err))
-    .then(() => { if (msg.channel.type !== "dm" && client.config.bot) msg.sendMessage("Commands have been sent to your DMs."); });
+    .then(() => { if (msg.channel.type !== "dm" && client.user.bot) msg.sendMessage("Commands have been sent to your DMs."); });
 };
 
 exports.conf = {

--- a/commands/System/invite.js
+++ b/commands/System/invite.js
@@ -1,5 +1,5 @@
 exports.run = async (client, msg) => {
-  if (!client.config.bot) return msg.reply("Why would you need an invite link for a selfbot...");
+  if (!client.user.bot) return msg.reply("Why would you need an invite link for a selfbot...");
 
   return msg.sendMessage([
     `To add ${client.user.username} to your discord guild:`,

--- a/commands/System/invite.js
+++ b/commands/System/invite.js
@@ -1,5 +1,5 @@
 exports.run = async (client, msg) => {
-  if (client.config.selfbot) return msg.reply("Why would you need an invite link for a selfbot...");
+  if (!client.config.bot) return msg.reply("Why would you need an invite link for a selfbot...");
 
   return msg.sendMessage([
     `To add ${client.user.username} to your discord guild:`,

--- a/events/message.js
+++ b/events/message.js
@@ -25,9 +25,9 @@ exports.handleMessage = (client, msg) => {
   // Ignore Self if true
   if (client.config.ignoreSelf && msg.author.id === client.user.id) return false;
   // Ignore other users if selfbot
-  if (!client.config.bot && msg.author.id !== client.user.id) return false;
+  if (!client.user.bot && msg.author.id !== client.user.id) return false;
   // Ignore self if bot
-  if (client.config.bot && msg.author.id === client.user.id) return false;
+  if (client.user.bot && msg.author.id === client.user.id) return false;
   return true;
 };
 

--- a/events/message.js
+++ b/events/message.js
@@ -24,10 +24,10 @@ exports.handleMessage = (client, msg) => {
   if (client.config.ignoreBots && msg.author.bot) return false;
   // Ignore Self if true
   if (client.config.ignoreSelf && msg.author.id === client.user.id) return false;
-  // Ignore other users if selfbot is true
-  if (client.config.selfbot && msg.author.id !== client.user.id) return false;
-  // Ignore other users if selfbot but config option is false
-  if (!client.config.selfbot && msg.author.id === client.user.id) return false;
+  // Ignore other users if selfbot
+  if (!client.config.bot && msg.author.id !== client.user.id) return false;
+  // Ignore self if bot
+  if (client.config.bot && msg.author.id === client.user.id) return false;
   return true;
 };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  Client: require('./client'),
+  Client: require('./classes/client'),
   PermLevels: require('./classes/permLevels')
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  Client: require('./client'),
+  PermLevels: require('./classes/permLevels')
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.20.1",
   "author": "Evelyne Lachance",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
-  "main": "client.js",
+  "main": "index.js",
   "scripts": {
     "test": "eslint classes commands finalizers functions inhibitors events client.js",
     "lint": "npm run test -- --fix"


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Minor, well technically major since it requires making a new komada.Client() instead of just new Komada(), but this is indev for something unreleased as stable anyway...
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Adds a way to add helper classes
- Adds a PermLevel helper class to help cleanly generate permlevel structures
- Automates all selfbot checks via client.user.bot (removes the need for client.config.selfbot)


### (If Applicable) What Issue does it fix?
 Fixes... 
