### PR TITLE
Drop fs-extra-promise support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A helper class for generating permission levels. It can be accessed via require('komada').PermLevels, and is used via permlevels.addLevel(level, break, checkFunction). Once you have all levels added, simply pass permlevels.structure to your client.config as the "permStructure" property.
 
 ### Changed
+- Dropped support for fs-extra-promise in favor to fs-extra ^3.0.0.
 - Changed fetchMessages to fetchMessage (backend change)
 - Backend is now class based. Users main files will need to be updated. The interface is the same as creating a discord.js client, only using komada, and with komada config. No more use of start, but client.login(token) is needed now.
 - Usage will no longer be calculated everytime a command is run, but instead stored in command.usage.
@@ -26,7 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed core log func, into an event. You can now log anything by running client.emit('log', data, type);
 - runMessageMonitors has been moved into the new Message core event.
 - dotenv dependancy has been changed to a peerdep.
-- fs-extra-promise has been updated to the latest version.
 - Minimum node version is now v7.6.x
 - Remaining Utils have been moved to the classes folder.
 - Use Discord.Permissions to generate and keep cached an implied permissions object, instead of generating a new object every time a command is run.

--- a/classes/Configuration Types/Config.js
+++ b/classes/Configuration Types/Config.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-underscore-dangle, no-unused-vars, no-throw-literal, guard-for-in, no-prototype-builtins */
-const fs = require("fs-extra-promise");
+const fs = require("fs-extra");
 const path = require("path");
 const Types = require("./types");
 const Discord = require("discord.js");
@@ -218,7 +218,7 @@ class Config {
       default:
         throw "Unsupported Configuration type. Cannot set the value.";
     }
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -239,7 +239,7 @@ class Config {
         config[key].setMin(defaultMinValue);
       });
     }
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -260,7 +260,7 @@ class Config {
         config[key].setMax(defaultMaxValue);
       });
     }
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -282,7 +282,7 @@ class Config {
         config[key].add(defaultValue);
       });
     }
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -304,7 +304,7 @@ class Config {
         config[key].del(defaultValue);
       });
     }
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -322,7 +322,7 @@ class Config {
     guildConfs.forEach((config) => {
       config[key].toggle();
     });
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     return defaultConf[key];
   }
 
@@ -363,7 +363,7 @@ class Config {
     guildConfs.forEach((config) => {
       config.addKey(key, defaultValue, type);
     });
-    fs.outputJSONAsync(path.resolve(`${dataDir}${path.sep}${defaultFile}`), defaultConf);
+    fs.outputJSON(path.resolve(`${dataDir}${path.sep}${defaultFile}`), defaultConf);
     return defaultConf;
   }
 
@@ -380,7 +380,7 @@ class Config {
       return `The key ${key} is core and cannot be deleted.`;
     }
     delete defaultConf[key];
-    fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
+    fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf);
     guildConfs.forEach((config) => {
       config.delKey(key);
     });
@@ -396,7 +396,7 @@ class Config {
   static insert(guild) {
     if (!guild) return "Please specify a guild to remove.";
     guildConfs.set(guild.id, new Config(guild.client, guild, defaultConf));
-    fs.outputJSONAsync(`${dataDir}${path.sep}${guild.id}.json`, guildConfs.get(guild.id));
+    fs.outputJSON(`${dataDir}${path.sep}${guild.id}.json`, guildConfs.get(guild.id));
     return `Inserted ${guild.name} succesfully.`;
   }
 
@@ -409,7 +409,7 @@ class Config {
   static remove(guild) {
     if (!guild) return "Please specify a guild to remove.";
     guildConfs.delete(guild.id);
-    fs.removeAsync(path.resolve(`${dataDir}${path.sep}${guild.id}.json`));
+    fs.remove(path.resolve(`${dataDir}${path.sep}${guild.id}.json`));
     return `Removed ${guild.name} succesfully.`;
   }
 
@@ -428,14 +428,14 @@ class Config {
       lang: { type: "String", data: "en" },
     };
     dataDir = path.resolve(`${client.clientBaseDir}${path.sep}bwd${path.sep}conf`);
-    fs.ensureFileAsync(`${dataDir}${path.sep}${defaultFile}`).catch(err => client.emit("log", err, "error"));
-    fs.readJSONAsync(path.resolve(`${dataDir}${path.sep}${defaultFile}`))
+    fs.ensureFile(`${dataDir}${path.sep}${defaultFile}`).catch(err => client.emit("log", err, "error"));
+    fs.readJSON(path.resolve(`${dataDir}${path.sep}${defaultFile}`))
   .then((conf) => {
     if (conf) defaultConf = conf;
   })
-  .catch(() => fs.outputJSONAsync(`${dataDir}${path.sep}${defaultFile}`, defaultConf));
+  .catch(() => fs.outputJSON(`${dataDir}${path.sep}${defaultFile}`, defaultConf));
     client.guilds.forEach((guild) => {
-      fs.readJSONAsync(path.resolve(`${dataDir}${path.sep}${guild.id}.json`))
+      fs.readJSON(path.resolve(`${dataDir}${path.sep}${guild.id}.json`))
   .then((thisConf) => {
     guildConfs.set(guild.id, new Config(client, guild, thisConf));
   }).catch(() => {

--- a/classes/client.js
+++ b/classes/client.js
@@ -43,6 +43,7 @@ module.exports = class Komada extends Discord.Client {
       finalizers: config.disabled.finalizers || [],
       monitors: config.disabled.monitors || [],
       providers: config.disabled.providers || [],
+      extendables: config.disabled.extendables || [],
     };
     this.funcs = new Loader(this);
     this.argResolver = new ArgResolver(this);

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra-promise");
+const fs = require("fs-extra");
 const { exec } = require("child_process");
 const { sep } = require("path");
 const Discord = require("discord.js");
@@ -46,16 +46,16 @@ module.exports = class Loader {
   }
 
   async loadFunctions() {
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}functions${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}functions${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.functions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}functions${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}functions${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}functions${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
@@ -71,7 +71,7 @@ module.exports = class Loader {
   async reloadFunction(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}functions${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}functions${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     if (this[name]) delete this[name];
     await this.loadFiles([file], this.client.clientBaseDir, this.loadNewFunction, this.reloadFunction)
@@ -91,8 +91,8 @@ module.exports = class Loader {
   }
 
   async walkCommandDirectories(dir) {
-    const files = await fs.readdirAsync(dir)
-      .catch(() => { fs.ensureDirAsync(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const files = await fs.readdir(dir)
+      .catch(() => { fs.ensureDir(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (!files) return false;
     await this.loadFiles(files.filter(file => file.endsWith(".js")
       && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
@@ -100,7 +100,7 @@ module.exports = class Loader {
       .catch((err) => { throw err; });
     const subfolders = [];
     const mps1 = files.filter(file => !file.includes(".")).map(async (folder) => {
-      const subFiles = await fs.readdirAsync(`${dir}${folder}${sep}`);
+      const subFiles = await fs.readdir(`${dir}${folder}${sep}`);
       if (!subFiles) return true;
       subFiles.filter(file => !file.includes(".")).forEach(subfolder => subfolders.push({ folder, subfolder }));
       return this.loadFiles(subFiles.filter(file => file.endsWith(".js")
@@ -110,7 +110,7 @@ module.exports = class Loader {
     });
     await Promise.all(mps1).catch((err) => { throw err; });
     const mps2 = subfolders.map(async (subfolder) => {
-      const subSubFiles = await fs.readdirAsync(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
+      const subSubFiles = await fs.readdir(`${dir}${subfolder.folder}${sep}${subfolder.subfolder}${sep}`);
       if (!subSubFiles) return true;
       return this.loadFiles(subSubFiles.filter(file => file.endsWith(".js")
         && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
@@ -150,7 +150,7 @@ module.exports = class Loader {
       fileToCheck = file.split(sep)[file.split(sep).length - 1];
       dirToCheck = `${dir}${file.split(sep).slice(0, -1).join(sep)}`;
     }
-    const files = await fs.readdirAsync(dirToCheck);
+    const files = await fs.readdir(dirToCheck);
     if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file}`;
     this.client.aliases.forEach((cmd, alias) => {
       if (cmd === name) this.client.aliases.delete(alias);
@@ -163,16 +163,16 @@ module.exports = class Loader {
 
   async loadCommandInhibitors() {
     this.client.commandInhibitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}inhibitors${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}inhibitors${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.inhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}inhibitors${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}inhibitors${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}inhibitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
@@ -189,7 +189,7 @@ module.exports = class Loader {
   async reloadInhibitor(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}inhibitors${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}inhibitors${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     await this.loadFiles([file], this.client.clientBaseDir, this.loadNewInhibitor, this.reloadInhibitor)
       .catch((err) => { throw err; });
@@ -204,16 +204,16 @@ module.exports = class Loader {
 
   async loadCommandFinalizers() {
     this.client.commandFinalizers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}finalizers${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}finalizers${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.finalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}finalizers${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}finalizers${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}finalizers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
@@ -229,7 +229,7 @@ module.exports = class Loader {
   async reloadFinalizer(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}finalizers${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}finalizers${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     await this.loadFiles([file], this.client.clientBaseDir, this.loadNewFinalizer, this.reloadFinalizer)
       .catch((err) => { throw err; });
@@ -240,16 +240,16 @@ module.exports = class Loader {
   async loadEvents() {
     this.client.eventHandlers.forEach((listener, event) => this.client.removeListener(event, listener));
     this.client.eventHandlers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}events${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}events${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.events.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}events${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}events${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}events${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
@@ -267,7 +267,7 @@ module.exports = class Loader {
   async reloadEvent(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}events${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}events${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     const listener = this.client.eventHandlers.get(name);
     if (listener) this.client.removeListener(name, listener);
@@ -278,16 +278,16 @@ module.exports = class Loader {
 
   async loadMessageMonitors() {
     this.client.messageMonitors.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}monitors${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}monitors${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.monitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}monitors${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}monitors${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}monitors${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
@@ -303,7 +303,7 @@ module.exports = class Loader {
   async reloadMessageMonitor(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}monitors${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}monitors${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     await this.loadFiles([file], this.client.clientBaseDir, this.loadNewMessageMonitor, this.reloadMessageMonitor)
       .catch((err) => { throw err; });
@@ -313,16 +313,16 @@ module.exports = class Loader {
 
   async loadProviders() {
     this.client.providers.clear();
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}providers${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}providers${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.providers.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}providers${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}providers${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}providers${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
@@ -338,7 +338,7 @@ module.exports = class Loader {
   async reloadProvider(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const files = await fs.readdirAsync(`${this.client.clientBaseDir}providers${sep}`);
+    const files = await fs.readdir(`${this.client.clientBaseDir}providers${sep}`);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     await this.loadFiles([file], this.client.clientBaseDir, this.loadNewProvider, this.reloadProvider)
       .catch((err) => { throw err; });
@@ -347,16 +347,16 @@ module.exports = class Loader {
   }
 
   async loadExtendables() {
-    const coreFiles = await fs.readdirAsync(`${this.client.coreBaseDir}extendables${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.coreBaseDir}extendables${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const coreFiles = await fs.readdir(`${this.client.coreBaseDir}extendables${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.coreBaseDir}extendables${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.extendables.includes(file.split(".")[0]) || !this.client.config.disabled.extendables.includes(file.split(".")[0])))
         , this.client.coreBaseDir, this.loadNewExtendable, this.loadExtendables)
         .catch((err) => { throw err; });
     }
-    const userFiles = await fs.readdirAsync(`${this.client.clientBaseDir}extendables${sep}`)
-      .catch(() => { fs.ensureDirAsync(`${this.client.clientBaseDir}extendables${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+    const userFiles = await fs.readdir(`${this.client.clientBaseDir}extendables${sep}`)
+      .catch(() => { fs.ensureDir(`${this.client.clientBaseDir}extendables${sep}`).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.client.clientBaseDir, this.loadNewExtendable, this.loadExtendables)
         .catch((err) => { throw err; });

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -1,9 +1,9 @@
-const util = require("util").inspect;
+const { inspect } = require("util");
 
 exports.run = async (client, msg, [action, key, ...value]) => {
   switch (action) {
     case "list": {
-      return msg.sendCode("json", util(msg.guildConf));
+      return msg.sendCode("json", inspect(msg.guildConf));
     }
     case "get": {
       if (!key) return msg.sendMessage("Please provide a key you wish to view");

--- a/commands/System/eval.js
+++ b/commands/System/eval.js
@@ -1,4 +1,4 @@
-const inspect = require("util").inspect;
+const { inspect } = require("util");
 
 /* eslint-disable no-eval */
 exports.run = async (client, msg, [code]) => {

--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -1,4 +1,4 @@
-const fs = require("fs-extra-promise");
+const fs = require("fs-extra");
 const path = require("path");
 
 /* eslint-disable no-throw-literal */
@@ -14,7 +14,7 @@ exports.run = async (client, msg, [type, name]) => {
     monitor: client.funcs.reloadMessageMonitor,
   };
   const isCommand = type === "command" ? "System/" : "";
-  fs.copyAsync(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
+  fs.copy(path.resolve(`${coreDir}/${type}s/${isCommand}${name}.js`), path.resolve(`${clientDir}/${type}s/${isCommand}${name}.js`))
     .then(() => {
       reload[type].call(client.funcs, `${isCommand}${name}`).catch((response) => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,4 +1,3 @@
 exports.run = (client, guild) => {
-  if (!guild.available) return;
-  client.configuration.insert(guild);
+  if (guild.available) client.configuration.insert(guild);
 };

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,4 +1,3 @@
 exports.run = (client, guild) => {
-  if (!guild.available) return;
-  client.configuration.remove(guild);
+  if (guild.available) client.configuration.remove(guild);
 };

--- a/extendables/sendMessage.js
+++ b/extendables/sendMessage.js
@@ -11,8 +11,8 @@ exports.extend = function (content = "", options = {}) {
   if (!options.embed) options.embed = null;
   if (commandMessage && !("files" in options)) return commandMessage.response.edit(content, options);
   return this.channel.send(content, options)
-      .then((mes) => {
-        if (mes.constructor.name === "Message" && !("files" in options)) this.client.commandMessages.set(this.id, { trigger: this, response: mes });
-        return mes;
-      });
+    .then((mes) => {
+      if (mes.constructor.name === "Message" && !("files" in options)) this.client.commandMessages.set(this.id, { trigger: this, response: mes });
+      return mes;
+    });
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "discord.js": "hydrabolt/discord.js",
-    "fs-extra-promise": "^1.0.0",
+    "fs-extra": "^3.0.0",
     "moment": "^2.16.0",
     "moment-duration-format": "^1.3.0",
     "performance-now": "^2.1.0"


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
minor

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Drop `fs-extra-promise` support in favor to `fs-extra` **v3.0.0**, as this version is able to return promises.

### (If Applicable) What Issue does it fix?
 Fixes... nothing, just one dependency less.

### Tested and worked
- [x] Ensuring client-base folders
- [x] Loading files
- [x] Ensuring config.json (default configs) inside ./bwd
- [x] Transfer command