### PR TITLE
Added support for commandFinalizers

### DIFF
--- a/commands/System/download.js
+++ b/commands/System/download.js
@@ -11,7 +11,7 @@ const mod = { exports: {} };
 /* eslint-disable no-throw-literal, no-use-before-define */
 exports.run = async (client, msg, [link, piece, folder = "Downloaded"]) => {
   const proposedURL = types.includes(link) ? `${piecesURL}${link}/${piece}.js` : link;
-  if (link === "command" && !/\w+\/\w+/.test(piece)) {
+  if (link === "commands" && !/\w+\/\w+/.test(piece)) {
     return msg.sendMessage(`${msg.author} | You provided an invalid or no subfolder for a command. Please provide a valid folder name from the Pieces Repo. Example: Misc/test`);
   }
 


### PR DESCRIPTION
Well, I missed this one while I was updating the docs.

### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
patch

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Now, Download.js v2 supports finalizers.


### (If Applicable) What Issue does it fix?
 Fixes... finalizers being not able to be downloaded.
