### PR TITLE
Let the arguments be parsed by Discord.js

### DIFF
--- a/extendables/send.js
+++ b/extendables/send.js
@@ -5,6 +5,6 @@ exports.conf = {
 };
 
 // eslint-disable-next-line func-names
-exports.extend = function (content = "", options = {}) {
+exports.extend = function (content, options) {
   return this.sendMessage(content, options);
 };

--- a/extendables/sendMessage.js
+++ b/extendables/sendMessage.js
@@ -5,7 +5,7 @@ exports.conf = {
 };
 
 // eslint-disable-next-line func-names
-exports.extend = function (content = "", options = {}) {
+exports.extend = function (content, options) {
   if (!this.channel) return this.send(content, options);
   const commandMessage = this.client.commandMessages.get(this.id);
   if (!options.embed) options.embed = null;

--- a/extendables/sendMessage.js
+++ b/extendables/sendMessage.js
@@ -8,11 +8,10 @@ exports.conf = {
 exports.extend = function (content, options) {
   if (!this.channel) return this.send(content, options);
   const commandMessage = this.client.commandMessages.get(this.id);
-  if (!options.embed) options.embed = null;
-  if (commandMessage && !("files" in options)) return commandMessage.response.edit(content, options);
+  if (commandMessage && (!options || !("files" in options))) return commandMessage.response.edit(content, options);
   return this.channel.send(content, options)
     .then((mes) => {
-      if (mes.constructor.name === "Message" && !("files" in options)) this.client.commandMessages.set(this.id, { trigger: this, response: mes });
+      if (mes.constructor.name === "Message" && (!options || !("files" in options))) this.client.commandMessages.set(this.id, { trigger: this, response: mes });
       return mes;
     });
 };


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Message#sendMessage({ embed }); will always send `[object Object]`. With this path, it'll do the same as Channel#send from Discord.js

### (If Applicable) What Issue does it fix?
 Fixes... Message#sendMessage
