### PR TITLE
update loader to use path.resolve

### DIFF
--- a/classes/client.js
+++ b/classes/client.js
@@ -45,6 +45,8 @@ module.exports = class Komada extends Discord.Client {
       providers: config.disabled.providers || [],
       extendables: config.disabled.extendables || [],
     };
+    this.coreBaseDir = path.join(__dirname, "../");
+    this.clientBaseDir = `${process.env.clientDir || process.cwd()}${path.sep}`;
     this.funcs = new Loader(this);
     this.argResolver = new ArgResolver(this);
     this.helpStructure = new Map();
@@ -69,8 +71,6 @@ module.exports = class Komada extends Discord.Client {
       escapeMarkdown: Discord.escapeMarkdown,
       splitMessage: Discord.splitMessage,
     };
-    this.coreBaseDir = path.join(__dirname, "../");
-    this.clientBaseDir = `${process.env.clientDir || process.cwd()}${path.sep}`;
     this.guildConfs = Config.guildConfs;
     this.configuration = Config;
     this.application = null;

--- a/classes/client.js
+++ b/classes/client.js
@@ -129,6 +129,7 @@ module.exports = class Komada extends Discord.Client {
       return true;
     }));
     await this.configuration.initialize(this);
+    this.setInterval(this.sweepCommandMessages.bind(this), this.commandMessageLifetime);
     this.ready = true;
     this.emit("log", this.config.readyMessage || `Successfully initialized. Ready to serve ${this.guilds.size} guilds.`);
   }

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -66,7 +66,7 @@ module.exports = class Loader {
 
   async loadFunctions() {
     const coreFiles = await fs.readdir(this.coreDirs.functions)
-      .catch(() => { fs.ensureDir(this.coreDirs.functions).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.functions).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.functions.includes(file.split(".")[0]) || !this.client.config.disabled.functions.includes(file.split(".")[0])))
@@ -74,7 +74,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.functions)
-      .catch(() => { fs.ensureDir(this.clientDirs.functions).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.functions).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.functions, this.loadNewFunction, this.loadFunctions)
         .catch((err) => { throw err; });
@@ -111,7 +111,7 @@ module.exports = class Loader {
 
   async walkCommandDirectories(dir) {
     const files = await fs.readdir(dir)
-      .catch(() => { fs.ensureDir(dir).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(dir).catch(err => this.client.emit("error", err)); });
     if (!files) return false;
     await this.loadFiles(files.filter(file => file.endsWith(".js")
       && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
@@ -183,7 +183,7 @@ module.exports = class Loader {
   async loadCommandInhibitors() {
     this.client.commandInhibitors.clear();
     const coreFiles = await fs.readdir(this.coreDirs.inhibitors)
-      .catch(() => { fs.ensureDir(this.coreDirs.inhibitors).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.inhibitors).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.inhibitors.includes(file.split(".")[0]) || !this.client.config.disabled.inhibitors.includes(file.split(".")[0])))
@@ -191,7 +191,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.inhibitors)
-      .catch(() => { fs.ensureDir(this.clientDirs.inhibitors).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.inhibitors).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.inhibitors, this.loadNewInhibitor, this.loadCommandInhibitors)
         .catch((err) => { throw err; });
@@ -224,7 +224,7 @@ module.exports = class Loader {
   async loadCommandFinalizers() {
     this.client.commandFinalizers.clear();
     const coreFiles = await fs.readdir(this.coreDirs.finalizers)
-      .catch(() => { fs.ensureDir(this.coreDirs.finalizers).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.finalizers).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.finalizers.includes(file.split(".")[0]) || !this.client.config.disabled.finalizers.includes(file.split(".")[0])))
@@ -232,7 +232,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.finalizers)
-      .catch(() => { fs.ensureDir(this.clientDirs.finalizers).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.finalizers).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.finalizers, this.loadNewFinalizer, this.loadCommandFinalizers)
         .catch((err) => { throw err; });
@@ -260,7 +260,7 @@ module.exports = class Loader {
     this.client.eventHandlers.forEach((listener, event) => this.client.removeListener(event, listener));
     this.client.eventHandlers.clear();
     const coreFiles = await fs.readdir(this.coreDirs.events)
-      .catch(() => { fs.ensureDir(this.coreDirs.events).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.events).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.events.includes(file.split(".")[0]) || !this.client.config.disabled.events.includes(file.split(".")[0])))
@@ -268,7 +268,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.events)
-      .catch(() => { fs.ensureDir(this.clientDirs.events).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.events).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.events, this.loadNewEvent, this.loadEvents)
         .catch((err) => { throw err; });
@@ -298,7 +298,7 @@ module.exports = class Loader {
   async loadMessageMonitors() {
     this.client.messageMonitors.clear();
     const coreFiles = await fs.readdir(this.coreDirs.monitors)
-      .catch(() => { fs.ensureDir(this.coreDirs.monitors).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.monitors).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.monitors.includes(file.split(".")[0]) || !this.client.config.disabled.monitors.includes(file.split(".")[0])))
@@ -306,7 +306,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.monitors)
-      .catch(() => { fs.ensureDir(this.clientDirs.monitors).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.monitors).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.monitors, this.loadNewMessageMonitor, this.loadMessageMonitors)
         .catch((err) => { throw err; });
@@ -333,7 +333,7 @@ module.exports = class Loader {
   async loadProviders() {
     this.client.providers.clear();
     const coreFiles = await fs.readdir(this.coreDirs.providers)
-      .catch(() => { fs.ensureDir(this.coreDirs.providers).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.providers).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.providers.includes(file.split(".")[0]) || !this.client.config.disabled.providers.includes(file.split(".")[0])))
@@ -341,7 +341,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.providers)
-      .catch(() => { fs.ensureDir(this.clientDirs.providers).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.providers).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.providers, this.loadNewProvider, this.loadProviders)
         .catch((err) => { throw err; });
@@ -367,7 +367,7 @@ module.exports = class Loader {
 
   async loadExtendables() {
     const coreFiles = await fs.readdir(this.coreDirs.extendables)
-      .catch(() => { fs.ensureDir(this.coreDirs.extendables).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.coreDirs.extendables).catch(err => this.client.emit("error", err)); });
     if (coreFiles) {
       await this.loadFiles(coreFiles.filter(file => file.endsWith(".js")
         && (coreProtected.extendables.includes(file.split(".")[0]) || !this.client.config.disabled.extendables.includes(file.split(".")[0])))
@@ -375,7 +375,7 @@ module.exports = class Loader {
         .catch((err) => { throw err; });
     }
     const userFiles = await fs.readdir(this.clientDirs.extendables)
-      .catch(() => { fs.ensureDir(this.clientDirs.extendables).catch(err => this.client.emit("error", this.client.funcs.newError(err))); });
+      .catch(() => { fs.ensureDir(this.clientDirs.extendables).catch(err => this.client.emit("error", err)); });
     if (userFiles) {
       await this.loadFiles(userFiles.filter(file => file.endsWith(".js")), this.clientDirs.extendables, this.loadNewExtendable, this.loadExtendables)
         .catch((err) => { throw err; });

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -82,9 +82,9 @@ module.exports = class Loader {
     return (coreFiles ? coreFiles.length : 0) + (userFiles ? userFiles.length : 0);
   }
 
-  loadNewFunction(file) {
-    this[file.split(".")[0]] = require(file);
-    delete require.cache[file];
+  loadNewFunction(file, dir) {
+    this[file.split(".")[0]] = require(join(dir, file));
+    delete require.cache[join(dir, file)];
   }
 
   async reloadFunction(name) {
@@ -139,8 +139,8 @@ module.exports = class Loader {
     return Promise.all(mps2).catch((err) => { throw err; });
   }
 
-  loadNewCommand(file) {
-    const cmd = require(file);
+  loadNewCommand(file, dir) {
+    const cmd = require(join(dir, file));
     cmd.help.fullCategory = file.split(sep).slice(0, -1);
     cmd.help.subCategory = cmd.help.fullCategory[1] || "General";
     cmd.help.category = cmd.help.fullCategory[0] || "General";
@@ -149,7 +149,7 @@ module.exports = class Loader {
     cmd.conf.aliases = cmd.conf.aliases || [];
     cmd.conf.aliases.forEach(alias => this.client.aliases.set(alias, cmd.help.name));
     cmd.usage = new ParsedUsage(this.client, cmd);
-    delete require.cache[file];
+    delete require.cache[join(dir, file)];
   }
 
   async reloadCommand(name) {
@@ -200,9 +200,9 @@ module.exports = class Loader {
     return this.client.commandInhibitors.size;
   }
 
-  loadNewInhibitor(file) {
-    this.client.commandInhibitors.set(file.split(".")[0], require(file));
-    delete require.cache[file];
+  loadNewInhibitor(file, dir) {
+    this.client.commandInhibitors.set(file.split(".")[0], require(join(dir, file)));
+    delete require.cache[join(dir, file)];
   }
 
   async reloadInhibitor(name) {
@@ -240,9 +240,9 @@ module.exports = class Loader {
     return this.client.commandFinalizers.size;
   }
 
-  loadNewFinalizer(file) {
-    this.client.commandFinalizers.set(file.split(".")[0], require(file));
-    delete require.cache[file];
+  loadNewFinalizer(file, dir) {
+    this.client.commandFinalizers.set(file.split(".")[0], require(join(dir, file)));
+    delete require.cache[join(dir, file)];
   }
 
   async reloadFinalizer(name) {
@@ -276,11 +276,11 @@ module.exports = class Loader {
     return this.client.eventHandlers.size;
   }
 
-  loadNewEvent(file) {
+  loadNewEvent(file, dir) {
     const eventName = file.split(".")[0];
-    this.client.eventHandlers.set(eventName, (...args) => require(file).run(this.client, ...args));
+    this.client.eventHandlers.set(eventName, (...args) => require(join(dir, file)).run(this.client, ...args));
     this.client.on(eventName, this.client.eventHandlers.get(eventName));
-    delete require.cache[file];
+    delete require.cache[join(dir, file)];
   }
 
   async reloadEvent(name) {
@@ -314,9 +314,9 @@ module.exports = class Loader {
     return this.client.messageMonitors.size;
   }
 
-  loadNewMessageMonitor(file) {
-    this.client.messageMonitors.set(file.split(".")[0], require(file));
-    delete require.cache[file];
+  loadNewMessageMonitor(file, dir) {
+    this.client.messageMonitors.set(file.split(".")[0], require(join(dir, file)));
+    delete require.cache[join(dir, file)];
   }
 
   async reloadMessageMonitor(name) {
@@ -349,9 +349,9 @@ module.exports = class Loader {
     return this.client.providers.size;
   }
 
-  loadNewProvider(file) {
-    this.client.providers.set(file.split(".")[0], require(file));
-    delete require.cache[file];
+  loadNewProvider(file, dir) {
+    this.client.providers.set(file.split(".")[0], require(join(dir, file)));
+    delete require.cache[join(dir, file)];
   }
 
   async reloadProvider(name) {
@@ -383,8 +383,8 @@ module.exports = class Loader {
     return (coreFiles ? coreFiles.length : 0) + (userFiles ? userFiles.length : 0);
   }
 
-  loadNewExtendable(file) {
-    const extendable = require(file);
+  loadNewExtendable(file, dir) {
+    const extendable = require(join(dir, file));
     let myExtend;
     switch (extendable.conf.type.toLowerCase()) {
       case "set":
@@ -403,13 +403,13 @@ module.exports = class Loader {
     extendable.conf.appliesTo.forEach((structure) => {
       Object.defineProperty(Discord[structure].prototype, extendable.conf.method, myExtend);
     });
-    delete require.cache[file];
+    delete require.cache[join(dir, file)];
   }
 
 
   async loadFiles(files, dir, loadNew, startOver) {
     try {
-      files.forEach(file => loadNew.call(this, join(dir, file)));
+      files.forEach(file => loadNew.call(this, file, dir));
     } catch (error) {
       if (error.code === "MODULE_NOT_FOUND") {
         const missingModule = /'([^']+)'/g.exec(error.toString());

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -26,6 +26,8 @@ module.exports = class Loader {
       inhibitors: resolve(this.client.coreBaseDir, "inhibitors"),
       finalizers: resolve(this.client.coreBaseDir, "finalizers"),
       events: resolve(this.client.coreBaseDir, "events"),
+      monitors: resolve(this.client.coreBaseDir, "monitors"),
+      providers: resolve(this.client.coreBaseDir, "providers"),
       extendables: resolve(this.client.coreBaseDir, "extendables"),
     };
     this.clientDirs = {
@@ -34,6 +36,8 @@ module.exports = class Loader {
       inhibitors: resolve(this.client.clientBaseDir, "inhibitors"),
       finalizers: resolve(this.client.clientBaseDir, "finalizers"),
       events: resolve(this.client.clientBaseDir, "events"),
+      monitors: resolve(this.client.clientBaseDir, "monitors"),
+      providers: resolve(this.client.clientBaseDir, "providers"),
       extendables: resolve(this.client.clientBaseDir, "extendables"),
     };
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -195,7 +195,7 @@
       "dev": true
     },
     "discord.js": {
-      "version": "github:hydrabolt/discord.js#d6041f9fb379b6652140600a3789c30ca4e9ce56"
+      "version": "github:hydrabolt/discord.js#b694ab1b8098f1f6664d350248e8f9008414f5ba"
     },
     "doctrine": {
       "version": "2.0.0",
@@ -395,9 +395,9 @@
       "dev": true
     },
     "fs-nextra": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fs-nextra/-/fs-nextra-0.0.4.tgz",
-      "integrity": "sha512-95Qhu2r4jU1KIPRnEEdhQcMDIskEw0z1l1moHCo3AKo6qYUteqRLg2ArDsByRV40ujwq/8j1xERCV98r94v3gw=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fs-nextra/-/fs-nextra-0.1.1.tgz",
+      "integrity": "sha512-WBNNVm2dIT4DfCMtf7aocyp3aZC+IowOe+53cARh6QtfjhOZ8hrJ2+HeoOvwi+Yq3et9FSVN/g5zYRtyRaoJPg=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,7 +195,7 @@
       "dev": true
     },
     "discord.js": {
-      "version": "github:hydrabolt/discord.js#d6041f9fb379b6652140600a3789c30ca4e9ce56"
+      "version": "github:hydrabolt/discord.js#b694ab1b8098f1f6664d350248e8f9008414f5ba"
     },
     "doctrine": {
       "version": "2.0.0",
@@ -395,9 +395,9 @@
       "dev": true
     },
     "fs-nextra": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/fs-nextra/-/fs-nextra-0.0.4.tgz",
-      "integrity": "sha512-95Qhu2r4jU1KIPRnEEdhQcMDIskEw0z1l1moHCo3AKo6qYUteqRLg2ArDsByRV40ujwq/8j1xERCV98r94v3gw=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fs-nextra/-/fs-nextra-0.1.1.tgz",
+      "integrity": "sha512-WBNNVm2dIT4DfCMtf7aocyp3aZC+IowOe+53cARh6QtfjhOZ8hrJ2+HeoOvwi+Yq3et9FSVN/g5zYRtyRaoJPg=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "discord.js": "hydrabolt/discord.js",
-    "fs-nextra": "^0.1.0",
+    "fs-nextra": "^0.1.1",
     "moment": "^2.16.0",
     "moment-duration-format": "^1.3.0",
     "performance-now": "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,7 +180,7 @@ del@^2.0.2:
 
 discord.js@hydrabolt/discord.js:
   version "12.0.0-dev"
-  resolved "https://codeload.github.com/hydrabolt/discord.js/tar.gz/d6041f9fb379b6652140600a3789c30ca4e9ce56"
+  resolved "https://codeload.github.com/hydrabolt/discord.js/tar.gz/b694ab1b8098f1f6664d350248e8f9008414f5ba"
   dependencies:
     long "^3.2.0"
     prism-media "^0.0.1"
@@ -434,9 +434,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-fs-nextra@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/fs-nextra/-/fs-nextra-0.0.4.tgz#956f4e1f9dedbaf8bd7629d691525178beb62a79"
+fs-nextra@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/fs-nextra/-/fs-nextra-0.1.1.tgz#3f8e5ff8fdfbab3c52eeb45e233c1637aa0c7e51"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-
-
-


### (If Applicable) What Issue does it fix?
 Fixes... loaders to use path resolve rather than template literals, and sweepCommandMessages was never running.
