### PR TITLE
Shutdown the provider (if it has a shutdown method)

### DIFF
--- a/classes/loader.js
+++ b/classes/loader.js
@@ -353,6 +353,8 @@ module.exports = class Loader {
   async reloadProvider(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
+    const provider = client.providers.get(name);
+    if (provider && provider.shutdown) await provider.shutdown();
     const files = await fs.readdir(this.clientDirs.providers);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;
     await this.loadFiles([file], this.clientDirs.providers, this.loadNewProvider, this.reloadProvider)

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -353,7 +353,7 @@ module.exports = class Loader {
   async reloadProvider(name) {
     const file = name.endsWith(".js") ? name : `${name}.js`;
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    const provider = client.providers.get(name);
+    const provider = this.client.providers.get(name);
     if (provider && provider.shutdown) await provider.shutdown();
     const files = await fs.readdir(this.clientDirs.providers);
     if (!files.includes(file)) throw `Could not find a reloadable file named ${file}`;


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Added `Provider#shutdown();` at Provider reload.

### (If Applicable) What Issue does it fix?
 Fixes... LevelDB provider requiring to be shutdown before re-initing.
