### PR TITLE
Provider folder organization

### DIFF
--- a/providers/json.js
+++ b/providers/json.js
@@ -3,9 +3,8 @@ const fs = require("fs-nextra");
 
 let baseDir;
 
-/* eslint-disable no-confusing-arrow */
 exports.init = (client) => {
-  baseDir = resolve(`${client.clientBaseDir}${sep}bwd${sep}conf`);
+  baseDir = resolve(client.clientBaseDir, "bwd", "provider", "json");
   return fs.ensureDir(baseDir).catch(err => client.emit("log", err, "error"));
 };
 
@@ -31,7 +30,7 @@ exports.createTable = table => fs.mkdir(baseDir + sep + table);
  * @returns {Promise<Void>}
  */
 exports.deleteTable = table => this.hasTable(table)
-  .then(exists => exists ? fs.emptyDir(baseDir + sep + table).then(() => fs.remove(baseDir + sep + table)) : null);
+  .then(exists => (exists ? fs.emptyDir(baseDir + sep + table).then(() => fs.remove(baseDir + sep + table)) : null));
 
 /* Document methods */
 
@@ -100,7 +99,7 @@ exports.delete = (table, document) => fs.unlink(`${baseDir + sep + table + sep +
 exports.conf = {
   moduleName: "json",
   enabled: true,
-  requiredModules: [],
+  requiredModules: ["fs-nextra"],
 };
 
 exports.help = {


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
minor
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- As Evie discussed before, two providers that rely on files (LevelDB and JSON) can accidentally use the files they shouldn't, causing issues. (The data from the JSON provider isn't compatible with LevelDB nor it's in the opposite).
- Added fs-nextra to required modules and fixed the `no-confusing-arrow` rule from ESLint.

### (If Applicable) What Issue does it fix?
 Fixes providers mixing up the folders.
