### PR TITLE
Raceconditions, SQL Support, SettingResolver, Error Handling...

### DIFF
--- a/classes/client.js
+++ b/classes/client.js
@@ -99,11 +99,11 @@ module.exports = class Komada extends Discord.Client {
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();
-    await this.settingGateway.init();
     await Promise.all(this.providers.map((piece) => {
       if (piece.init) return piece.init(this);
       return true;
     }));
+    await this.settingGateway.init();
     await Promise.all(Object.keys(this.funcs).map((key) => {
       if (this.funcs[key].init) return this.funcs[key].init(this);
       return true;

--- a/classes/client.js
+++ b/classes/client.js
@@ -30,6 +30,7 @@ module.exports = class Komada extends Discord.Client {
     super(config.clientOptions);
     this.config = config;
     this.config.provider = config.provider || {};
+    if (!config.disabled) config.disabled = {};
     this.config.disabled = {
       commands: config.disabled.commands || [],
       events: config.disabled.events || [],

--- a/classes/client.js
+++ b/classes/client.js
@@ -96,6 +96,10 @@ module.exports = class Komada extends Discord.Client {
     super.login(token);
   }
 
+  get schemaManager() {
+    return this.settingGateway.schemaManager;
+  }
+
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();

--- a/classes/client.js
+++ b/classes/client.js
@@ -99,6 +99,7 @@ module.exports = class Komada extends Discord.Client {
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();
+    await this.settingGateway.init();
     await Promise.all(Object.keys(this.funcs).map((key) => {
       if (this.funcs[key].init) return this.funcs[key].init(this);
       return true;
@@ -123,7 +124,6 @@ module.exports = class Komada extends Discord.Client {
       if (piece.init) return piece.init(this);
       return true;
     }));
-    await this.settingGateway.init();
     this.setInterval(this.sweepCommandMessages.bind(this), this.commandMessageLifetime);
     this.ready = true;
     this.emit("log", this.config.readyMessage || `Successfully initialized. Ready to serve ${this.guilds.size} guilds.`);

--- a/classes/client.js
+++ b/classes/client.js
@@ -100,12 +100,12 @@ module.exports = class Komada extends Discord.Client {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();
     await this.settingGateway.init();
-    await Promise.all(Object.keys(this.funcs).map((key) => {
-      if (this.funcs[key].init) return this.funcs[key].init(this);
-      return true;
-    }));
     await Promise.all(this.providers.map((piece) => {
       if (piece.init) return piece.init(this);
+      return true;
+    }));
+    await Promise.all(Object.keys(this.funcs).map((key) => {
+      if (this.funcs[key].init) return this.funcs[key].init(this);
       return true;
     }));
     await Promise.all(this.commands.map((piece) => {

--- a/classes/client.js
+++ b/classes/client.js
@@ -30,7 +30,6 @@ module.exports = class Komada extends Discord.Client {
     super(config.clientOptions);
     this.config = config;
     this.config.provider = config.provider || {};
-    this.config.disabled = config.disabled || {};
     this.config.disabled = {
       commands: config.disabled.commands || [],
       events: config.disabled.events || [],

--- a/classes/schemaManager.js
+++ b/classes/schemaManager.js
@@ -1,4 +1,4 @@
-const { sep, resolve } = require("path");
+const { resolve } = require("path");
 const fs = require("fs-nextra");
 
 const validTypes = ["User", "Channel", "Guild", "Role", "Boolean", "String", "Integer", "Float", "url", "Command"];
@@ -15,9 +15,9 @@ class SchemaManager {
    * @returns {void}
    */
   async init() {
-    const baseDir = resolve(`${this.client.clientBaseDir}${sep}bwd`);
+    const baseDir = resolve(this.client.clientBaseDir, "bwd");
     await fs.ensureDir(baseDir);
-    this.filePath = `${baseDir + sep}schema.json`;
+    this.filePath = resolve(baseDir, "schema.json");
     const schema = await fs.readJSON(this.filePath)
       .catch(() => fs.outputJSON(this.filePath, this.defaultDataSchema).then(() => this.defaultDataSchema));
     return this.validate(schema);
@@ -102,7 +102,7 @@ class SchemaManager {
    * @returns {void}
    */
   async force(action, key) {
-    const data = this.client.settingGateway.getAll();
+    const data = this.client.settingGateway.getAll("guilds");
     let value;
     if (action === "add") value = this.defaults[key];
     await Promise.all(data.map(async (obj) => {

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -14,7 +14,6 @@ module.exports = class SettingGateway extends CacheManager {
     this.engine = client.config.provider.engine || "json";
 
     this.resolver = new Resolver(client);
-    this.schemaManager = new SchemaManager(this.client);
   }
 
   /**
@@ -23,7 +22,9 @@ module.exports = class SettingGateway extends CacheManager {
    */
   async init() {
     this.provider = this.client.providers.get(this.engine);
+    if (this.provider.init) this.provider.init(this.client);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
+    this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");
     const data = await this.provider.getAll("guilds");

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -14,6 +14,7 @@ module.exports = class SettingGateway extends CacheManager {
     this.engine = client.config.provider.engine || "json";
 
     this.resolver = new Resolver(client);
+    this.schemaManager = new SchemaManager(this.client);
   }
 
   /**
@@ -23,9 +24,7 @@ module.exports = class SettingGateway extends CacheManager {
   async init() {
     this.provider = this.client.providers.get(this.engine);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
-    this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
-    if (this.provider.init) this.provider.init(this.client);
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");
     const data = await this.provider.getAll("guilds");
     if (data[0]) {

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -1,6 +1,6 @@
-const SettingResolver = require("./settingResolver.js");
-const CacheManager = require("./cacheManager.js");
-const SchemaManager = require("./schemaManager.js");
+const SettingResolver = require("./settingResolver");
+const CacheManager = require("./cacheManager");
+const SchemaManager = require("./schemaManager");
 const SQL = require("./sql");
 
 /* eslint-disable no-restricted-syntax */

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -167,7 +167,7 @@ module.exports = class SettingGateway extends CacheManager {
     if (!this.schema[key].array) throw `The key ${key} is not an Array.`;
     if (data === undefined) throw "You must specify the value to add or filter.";
     const target = await this.validateGuild(guild);
-    let result = await this.resolver[type.toLowerCase()](data, target, this.schema[key]);
+    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, target, this.schema[key]);
     if (result.id) result = result.id;
     const cache = this.get(target.id);
     if (type === "add") {

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -137,7 +137,7 @@ module.exports = class SettingGateway extends CacheManager {
     const settings = this.get(guild);
     guild = await this.validateGuild(guild);
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
-      if (this.schema[key] && this.schema[key].array) return Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](entry, guild, this.schema[key])));
+      if (this.schema[key] && this.schema[key].array) return { [key]: Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](entry, guild, this.schema[key]))) };
       return { [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](data, guild, this.schema[key]) : data };
     }));
     return Object.assign({}, ...resolved);

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -171,7 +171,7 @@ module.exports = class SettingGateway extends CacheManager {
       await this.sync(target.id);
       return result;
     }
-    if (!cache[key].includes(result)) throw `The value ${data} for the key ${key} already exists.`;
+    if (!cache[key].includes(result)) throw `The value ${data} for the key ${key} does not exist.`;
     cache[key] = cache[key].filter(v => v !== result);
     await this.provider.update("guilds", target.id, { [key]: cache[key] });
     await this.sync(target.id);

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -22,8 +22,8 @@ module.exports = class SettingGateway extends CacheManager {
    */
   async init() {
     this.provider = this.client.providers.get(this.engine);
-    if (this.provider.init) await this.provider.init(this.client);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
+    if (this.provider.init) await this.provider.init(this.client);
     this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -22,7 +22,7 @@ module.exports = class SettingGateway extends CacheManager {
    */
   async init() {
     this.provider = this.client.providers.get(this.engine);
-    if (this.provider.init) this.provider.init(this.client);
+    if (this.provider.init) await this.provider.init(this.client);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
     this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -25,6 +25,7 @@ module.exports = class SettingGateway extends CacheManager {
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
     this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
+    if (this.provider.init) this.provider.init(this.client);
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");
     const data = await this.provider.getAll("guilds");
     if (data[0]) {

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -134,8 +134,8 @@ module.exports = class SettingGateway extends CacheManager {
    * @returns {Object}
    */
   async getResolved(guild) {
-    guild = await this.validateGuild(guild);
     const settings = this.get(guild);
+    guild = await this.validateGuild(guild);
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
       if (this.schema[key] && this.schema[key].array) return Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], entry)));
       return { [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], data) : data };

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -1,6 +1,7 @@
-const Resolver = require("./Resolver.js");
-const CacheManager = require("./cacheManager.js");
-const SchemaManager = require("./schemaManager.js");
+const Resolver = require("./Resolver");
+const CacheManager = require("./cacheManager");
+const SchemaManager = require("./schemaManager");
+const SQL = require("./sql");
 
 /* eslint-disable no-restricted-syntax */
 module.exports = class SettingGateway extends CacheManager {
@@ -25,58 +26,17 @@ module.exports = class SettingGateway extends CacheManager {
     this.provider = this.client.providers.get(this.engine);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
     await this.schemaManager.init();
-    this.sql = this.provider.conf.sql;
+    this.sql = this.provider.conf.sql ? new SQL(this.client, this.provider) : false;
     if (!(await this.provider.hasTable("guilds"))) {
-      const SQLCreate = this.sql ? this.buildSQLSchema(this.schema) : undefined;
+      const SQLCreate = this.sql ? this.sql.buildSQLSchema(this.schema) : undefined;
       await this.provider.createTable("guilds", SQLCreate);
     }
     const data = await this.provider.getAll("guilds");
     if (this.sql) {
-      this.initDeserialize();
-      for (let i = 0; i < data.length; i++) this.deserializer(data[i]);
+      this.sql.initDeserialize();
+      for (let i = 0; i < data.length; i++) this.sql.deserializer(data[i]);
     }
     if (data[0]) for (const key of data) super.set(key.id, key);
-  }
-
-  /**
-   * [SQL ONLY] Init the deserialization keys for SQL providers.
-   * @returns {void}
-   */
-  initDeserialize() {
-    this.deserializeKeys = [];
-    for (const [key, value] of Object.entries(this.schema)) {
-      if (value.array === true) this.deserializeKeys.push(key);
-    }
-  }
-
-  /**
-   * [SQL ONLY] Deserialize stringified objects.
-   * @param {Object} data The GuildSettings object.
-   * @return {void}
-   */
-  deserializer(data) {
-    const deserialize = this.deserializeKeys;
-    for (let i = 0; i < deserialize.length; i++) data[deserialize[i]] = JSON.parse(data[deserialize[i]]);
-  }
-
-  buildSQLSchema(schema) {
-    const constants = this.provider.CONSTANTS;
-    if (!constants) {
-      this.client.emit("log", "This SQL Provider does not seem to have a CONSTANTS exports. Using built-in schema.", "error");
-      return ["id TEXT NOT NULL UNIQUE", `prefix TEXT NOT NULL DEFAULT '${this.defaults.prefix}'`, "adminRole TEXT", "modRole TEXT", "disabledCommands TEXT DEFAULT '[]'"];
-    }
-    const output = ["id TEXT NOT NULL UNIQUE"];
-    const selectType = value => constants[value.type] || "TEXT";
-    let sanitize = this.provider.sanitize;
-    if (!this.provider.sanitize) {
-      this.client.emit("log", "This SQL Provider does not seem to have a sanitize exports. It might corrupt.", "error");
-      sanitize = value => value;
-    }
-    for (const [key, value] of Object.entries(schema)) {
-      output.push(`${key} ${selectType(value.type)}${value.default ? ` NOT NULL DEFAULT ${sanitize(value.default)}` : ""}`);
-    }
-
-    return output;
   }
 
   /**
@@ -136,13 +96,13 @@ module.exports = class SettingGateway extends CacheManager {
   async sync(guild = null) {
     if (!guild) {
       const data = await this.provider.getAll("guilds");
-      if (this.sql) for (let i = 0; i < data.length; i++) this.deserializer(data[i]);
+      if (this.sql) for (let i = 0; i < data.length; i++) this.sql.deserializer(data[i]);
       for (const key of data) super.set(key.id, key);
       return;
     }
     const target = await this.validateGuild(guild);
     const data = await this.provider.get("guilds", target.id);
-    if (this.sql) this.deserializer(data);
+    if (this.sql) this.sql.deserializer(data);
     await super.set(target.id, data);
   }
 

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -122,7 +122,7 @@ module.exports = class SettingGateway extends CacheManager {
   }
 
   /**
-   * Update the configuration from a Guild configuration.
+   * Update a Guild's configuration.
    * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
    * @param {string} key The key to update.
    * @param {any} data The new value for the key.
@@ -137,6 +137,14 @@ module.exports = class SettingGateway extends CacheManager {
     return result;
   }
 
+  /**
+   * Update an array from the a Guild's configuration.
+   * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
+   * @param {string} type Either 'add' or 'remove'.
+   * @param {string} key The key from the Schema.
+   * @param {any} data The value to be added or removed.
+   * @returns {boolean}
+   */
   async updateArray(guild, type, key, data) {
     if (!["add", "remove"].includes(type)) throw "The type parameter must be either add or remove.";
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -137,8 +137,8 @@ module.exports = class SettingGateway extends CacheManager {
     const settings = this.get(guild);
     guild = await this.validateGuild(guild);
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
-      if (this.schema[key] && this.schema[key].array) return Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], entry)));
-      return { [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], data) : data };
+      if (this.schema[key] && this.schema[key].array) return Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](entry, guild, this.schema[key])));
+      return { [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](data, guild, this.schema[key]) : data };
     }));
     return Object.assign({}, ...resolved);
   }
@@ -186,7 +186,7 @@ module.exports = class SettingGateway extends CacheManager {
   async update(guild, key, data) {
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
     const target = await this.validateGuild(guild);
-    let result = await this.resolver[this.schema[key].type.toLowerCase()](target, this.schema[key], data);
+    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, target, this.schema[key]);
     if (result.id) result = result.id;
     await this.provider.update("guilds", target.id, { [key]: result });
     await this.sync(target.id);
@@ -199,7 +199,7 @@ module.exports = class SettingGateway extends CacheManager {
     if (!this.schema[key].array) throw `The key ${key} is not an Array.`;
     if (data === undefined) throw "You must specify the value to add or filter.";
     const target = await this.validateGuild(guild);
-    let result = await this.resolver[type.toLowerCase()](target, this.schema[key], data);
+    let result = await this.resolver[type.toLowerCase()](data, target, this.schema[key]);
     if (result.id) result = result.id;
     const cache = this.get(target.id);
     if (type === "add") {

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -14,6 +14,7 @@ module.exports = class SettingGateway extends CacheManager {
     this.engine = client.config.provider.engine || "json";
 
     this.resolver = new Resolver(client);
+    this.schemaManager = new SchemaManager(this.client);
   }
 
   /**
@@ -23,8 +24,6 @@ module.exports = class SettingGateway extends CacheManager {
   async init() {
     this.provider = this.client.providers.get(this.engine);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
-    if (this.provider.init) await this.provider.init(this.client);
-    this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");
     const data = await this.provider.getAll("guilds");

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -14,7 +14,6 @@ module.exports = class SettingGateway extends CacheManager {
     this.engine = client.config.provider.engine || "json";
 
     this.resolver = new Resolver(client);
-    this.schemaManager = new SchemaManager(client);
   }
 
   /**
@@ -24,6 +23,7 @@ module.exports = class SettingGateway extends CacheManager {
   async init() {
     this.provider = this.client.providers.get(this.engine);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
+    this.schemaManager = new SchemaManager(this.client);
     await this.schemaManager.init();
     if (!(await this.provider.hasTable("guilds"))) this.provider.createTable("guilds");
     const data = await this.provider.getAll("guilds");

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -94,11 +94,11 @@ module.exports = class SettingGateway extends CacheManager {
    * @returns {Object}
    */
   async getResolved(guild) {
-    const settings = this.get(guild);
     guild = await this.validateGuild(guild);
+    const settings = this.get(guild.id);
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
       if (this.schema[key] && this.schema[key].array) return { [key]: Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](entry, guild, this.schema[key]))) };
-      return { [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](data, guild, this.schema[key]) : data };
+      return { [key]: this.schema[key] && data ? this.resolver[this.schema[key].type.toLowerCase()](data, guild, this.schema[key]) : data };
     }));
     return Object.assign({}, ...resolved);
   }

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -135,7 +135,7 @@ module.exports = class SettingGateway extends CacheManager {
    */
   async getResolved(guild) {
     const settings = this.get(guild);
-    const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => ({ [key]: this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], data) })));
+    const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => ({ [key]: this.schema[key] ? this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], data) : data })));
     return Object.assign({}, ...resolved);
   }
 

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -134,7 +134,7 @@ module.exports = class SettingGateway extends CacheManager {
    * @returns {Object}
    */
   async getResolved(guild) {
-    guild = await this.resolver.guild(guild).catch((err) => { throw err; });
+    guild = await this.validateGuild(guild);
     const settings = this.get(guild);
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
       if (this.schema[key] && this.schema[key].array) return Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](guild, this.schema[key], entry)));

--- a/classes/settingResolver.js
+++ b/classes/settingResolver.js
@@ -2,7 +2,6 @@ const Resolver = require("./Resolver");
 
 /* eslint-disable no-throw-literal, class-methods-use-this */
 module.exports = class SettingResolver extends Resolver {
-
   async user(data) {
     const result = await super.user(data);
     if (!result) throw "This key expects a User Object or ID.";
@@ -87,5 +86,4 @@ module.exports = class SettingResolver extends Resolver {
     }
     return null;
   }
-
 };

--- a/classes/settingResolver.js
+++ b/classes/settingResolver.js
@@ -3,63 +3,63 @@ const Resolver = require("./Resolver");
 /* eslint-disable no-throw-literal, class-methods-use-this */
 module.exports = class SettingResolver extends Resolver {
 
-  async user(guild, { type, min, max }, data) {
+  async user(data) {
     const result = await super.user(data);
     if (!result) throw "This key expects a User Object or ID.";
     return result;
   }
 
-  async channel(guild, { type, min, max }, data) {
+  async channel(data) {
     const result = await super.channel(data);
     if (!result) throw "This key expects a Channel Object or ID.";
     return result;
   }
 
-  async guild(guild, { type, min, max }, data) {
+  async guild(data) {
     const result = await super.guild(data);
     if (!result) throw "This key expects a Guild ID.";
     return result;
   }
 
-  async role(guild, { type, min, max }, data) {
+  async role(data, guild) {
     const result = await super.role(data, guild) || guild.roles.find("name", data);
     if (!result) throw "This key expects a Role Object or ID.";
     return result;
   }
 
-  async boolean(guild, { type, min, max }, data) {
+  async boolean(data) {
     const result = await super.boolean(data);
     if (!result) throw "This key expects a Boolean.";
     return result;
   }
 
-  async string(guild, { type, min, max }, data) {
+  async string(data, guild, { min, max }) {
     const result = await super.string(data);
     SettingResolver.maxOrMin(result.length, min, max).catch((e) => { throw `The string length must be ${e} characters.`; });
     return result;
   }
 
-  async integer(guild, { type, min, max }, data) {
+  async integer(data, guild, { min, max }) {
     const result = await super.integer(data);
     if (!result) throw "This key expects an Integer value.";
     SettingResolver.maxOrMin(result, min, max).catch((e) => { throw `The integer value must be ${e}.`; });
     return result;
   }
 
-  async float(guild, { type, min, max }, data) {
+  async float(data, guild, { min, max }) {
     const result = await super.float(data);
     if (!result) throw "This key expects a Float value.";
     SettingResolver.maxOrMin(result, min, max).catch((e) => { throw `The float value must be ${e}.`; });
     return result;
   }
 
-  async url(guild, { type, min, max }, data) {
+  async url(data) {
     const result = await super.url(data);
     if (!result) throw "This key expects an URL (Uniform Resource Locator).";
     return result;
   }
 
-  async command(guild, { type, min, max }, data) {
+  async command(data) {
     const command = this.client.commands.get(data.toLowerCase()) || this.client.commands.get(this.client.aliases.get(data.toLowerCase()));
     if (!command) throw "This key expects a Command.";
     return command.help.name;

--- a/classes/settingResolver.js
+++ b/classes/settingResolver.js
@@ -1,0 +1,91 @@
+const Resolver = require("./Resolver");
+
+/* eslint-disable no-throw-literal, class-methods-use-this */
+module.exports = class SettingResolver extends Resolver {
+
+  async user(guild, { type, min, max }, data) {
+    const result = await super.user(data);
+    if (!result) throw "This key expects a User Object or ID.";
+    return result;
+  }
+
+  async channel(guild, { type, min, max }, data) {
+    const result = await super.channel(data);
+    if (!result) throw "This key expects a Channel Object or ID.";
+    return result;
+  }
+
+  async guild(guild, { type, min, max }, data) {
+    const result = await super.guild(data);
+    if (!result) throw "This key expects a Guild ID.";
+    return result;
+  }
+
+  async role(guild, { type, min, max }, data) {
+    const result = await super.role(data, guild) || guild.roles.find("name", data);
+    if (!result) throw "This key expects a Role Object or ID.";
+    return result;
+  }
+
+  async boolean(guild, { type, min, max }, data) {
+    const result = await super.boolean(data);
+    if (!result) throw "This key expects a Boolean.";
+    return result;
+  }
+
+  async string(guild, { type, min, max }, data) {
+    const result = await super.string(data);
+    SettingResolver.maxOrMin(result.length, min, max).catch((e) => { throw `The string length must be ${e} characters.`; });
+    return result;
+  }
+
+  async integer(guild, { type, min, max }, data) {
+    const result = await super.integer(data);
+    if (!result) throw "This key expects an Integer value.";
+    SettingResolver.maxOrMin(result, min, max).catch((e) => { throw `The integer value must be ${e}.`; });
+    return result;
+  }
+
+  async float(guild, { type, min, max }, data) {
+    const result = await super.float(data);
+    if (!result) throw "This key expects a Float value.";
+    SettingResolver.maxOrMin(result, min, max).catch((e) => { throw `The float value must be ${e}.`; });
+    return result;
+  }
+
+  async url(guild, { type, min, max }, data) {
+    const result = await super.url(data);
+    if (!result) throw "This key expects an URL (Uniform Resource Locator).";
+    return result;
+  }
+
+  async command(guild, { type, min, max }, data) {
+    const command = this.client.commands.get(data.toLowerCase()) || this.client.commands.get(this.client.aliases.get(data.toLowerCase()));
+    if (!command) throw "This key expects a Command.";
+    return command.help.name;
+  }
+
+  /**
+   * Check if the input is valid with min and/or max values.
+   * @static
+   * @param {any} value The value to check.
+   * @param {?number} min Min value.
+   * @param {?number} max Max value.
+   * @returns {?boolean}
+   */
+  static async maxOrMin(value, min, max) {
+    if (min && max) {
+      if (value >= min && value <= max) return true;
+      if (min === max) throw `exactly ${min}`;
+      throw `between ${min} and ${max}`;
+    } else if (min) {
+      if (value >= min) return true;
+      throw `longer than ${min}`;
+    } else if (max) {
+      if (value <= max) return true;
+      throw `shorter than ${max}`;
+    }
+    return null;
+  }
+
+};

--- a/classes/sql.js
+++ b/classes/sql.js
@@ -1,0 +1,88 @@
+const tuplify = s => [s.split(" ")[0], s.split(" ").slice(1).join(" ")];
+const DefaultDataTypes = {
+  String: "TEXT",
+  Integer: "INTEGER",
+  Float: "INTEGER",
+  AutoID: "INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE",
+  Timestamp: "DATETIME",
+  AutoTS: "DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL",
+};
+
+/* eslint-disable no-restricted-syntax */
+class SQL {
+  constructor(client, provider) {
+    this.client = client;
+    this.provider = provider;
+  }
+
+  buildSingleSQLSchema(value) {
+    let constants = this.provider.CONSTANTS;
+    if (!constants) {
+      this.client.emit("log", "This SQL Provider does not seem to have a CONSTANTS exports. Using built-in schema.", "error");
+      constants = DefaultDataTypes;
+    }
+    const selectType = schemaKey => constants[schemaKey] || "TEXT";
+    let { sanitize } = this.provider;
+    if (!sanitize) {
+      this.client.emit("log", "This SQL Provider does not seem to have a sanitize exports. It might corrupt.", "error");
+      sanitize = schemaKey => `'${schemaKey}'`;
+    }
+    const type = value.sql || value.default ? ` DEFAULT ${sanitize(value.default)}` : "";
+    return `${selectType(value.type)}${type}`;
+  }
+
+  buildSQLSchema(schema) {
+    const output = ["id TEXT NOT NULL UNIQUE"];
+    for (const [key, value] of Object.entries(schema)) {
+      output.push(`${key} ${this.buildSingleSQLSchema(key, value)}`);
+    }
+    return output;
+  }
+
+  /**
+   * [SQL ONLY] Init the deserialization keys for SQL providers.
+   * @param {Object} schema The schema object.
+   * @returns {void}
+   */
+  initDeserialize() {
+    this.deserializeKeys = [];
+    for (const [key, value] of Object.entries(this.schema)) {
+      if (value.array === true) this.deserializeKeys.push(key);
+    }
+  }
+
+  /**
+   * [SQL ONLY] Deserialize stringified objects.
+   * @param {Object} data The GuildSettings object.
+   * @return {void}
+   */
+  deserializer(data) {
+    const deserialize = this.deserializeKeys;
+    for (let i = 0; i < deserialize.length; i++) data[deserialize[i]] = JSON.parse(data[deserialize[i]]);
+  }
+
+  async updateColumns(schema, defaults, key) {
+    if (!this.provider.updateColumns) {
+      this.client.emit("log", "This SQL Provider does not seem to have a updateColumns exports. Force action cancelled.", "error");
+      return false;
+    }
+    const newSQLSchema = this.buildSQLSchema(schema).map(tuplify);
+    const keys = Object.keys(defaults);
+    if (!keys.includes("id")) keys.push("id");
+    const columns = keys.filter(k => k !== key);
+    await this.provider.updateColumns("guilds", columns, newSQLSchema);
+    this.initDeserialize();
+
+    return true;
+  }
+
+  get schema() {
+    return this.client.schemaManager.schema;
+  }
+
+  get defaults() {
+    return this.client.schemaManager.defaults;
+  }
+}
+
+module.exports = SQL;

--- a/classes/sql.js
+++ b/classes/sql.js
@@ -15,6 +15,11 @@ class SQL {
     this.provider = provider;
   }
 
+  /**
+   * Generate an automatic SQL schema for a single row.
+   * @param {Object} value The Schema<Value> object.
+   * @returns {string}
+   */
   buildSingleSQLSchema(value) {
     let constants = this.provider.CONSTANTS;
     if (!constants) {
@@ -31,6 +36,11 @@ class SQL {
     return `${selectType(value.type)}${type}`;
   }
 
+  /**
+   * Generate an automatic SQL schema for all rows.
+   * @param {any} schema The Schema Object.
+   * @returns {string[]}
+   */
   buildSQLSchema(schema) {
     const output = ["id TEXT NOT NULL UNIQUE"];
     for (const [key, value] of Object.entries(schema)) {
@@ -40,7 +50,7 @@ class SQL {
   }
 
   /**
-   * [SQL ONLY] Init the deserialization keys for SQL providers.
+   * Init the deserialization keys for SQL providers.
    * @param {Object} schema The schema object.
    * @returns {void}
    */
@@ -52,7 +62,7 @@ class SQL {
   }
 
   /**
-   * [SQL ONLY] Deserialize stringified objects.
+   * Deserialize stringified objects.
    * @param {Object} data The GuildSettings object.
    * @return {void}
    */
@@ -61,6 +71,13 @@ class SQL {
     for (let i = 0; i < deserialize.length; i++) data[deserialize[i]] = JSON.parse(data[deserialize[i]]);
   }
 
+  /**
+   * Create/Remove columns from a SQL database, by the current Schema.
+   * @param {Object} schema The Schema object.
+   * @param {Object} defaults The Schema<Defaults> object.
+   * @param {string} key The key which is updated.
+   * @returns {boolean}
+   */
   async updateColumns(schema, defaults, key) {
     if (!this.provider.updateColumns) {
       this.client.emit("log", "This SQL Provider does not seem to have a updateColumns exports. Force action cancelled.", "error");
@@ -76,10 +93,18 @@ class SQL {
     return true;
   }
 
+  /**
+   * Shortcut for Schema.
+   * @readonly
+   */
   get schema() {
     return this.client.schemaManager.schema;
   }
 
+  /**
+   * Shortcut for Schema<Defaults>
+   * @readonly
+   */
   get defaults() {
     return this.client.schemaManager.defaults;
   }

--- a/commands/System/reboot.js
+++ b/commands/System/reboot.js
@@ -1,6 +1,7 @@
-exports.run = async (client, msg) => msg.sendMessage("Rebooting...")
-    .then(() => process.exit())
-    .catch(err => client.emit("error", err));
+exports.run = async (client, msg) => {
+  await msg.sendMessage("Rebooting...").catch(err => client.emit("error", err));
+  process.exit();
+};
 
 exports.conf = {
   enabled: true,

--- a/commands/System/transfer.js
+++ b/commands/System/transfer.js
@@ -1,7 +1,6 @@
 const fs = require("fs-nextra");
 const { resolve } = require("path");
 
-/* eslint-disable no-throw-literal */
 exports.run = async (client, msg, [type, name]) => {
   const coreDir = client.coreBaseDir;
   const clientDir = client.clientBaseDir;
@@ -14,7 +13,9 @@ exports.run = async (client, msg, [type, name]) => {
     monitor: client.funcs.reloadMessageMonitor,
   };
   if (type === "command") name = `System/${name}`;
-  return fs.copy(resolve(`${coreDir}/${type}s/${name}.js`), resolve(`${clientDir}/${type}s/${name}.js`))
+  const fileLocation = resolve(coreDir, `${type}s`, `${name}.js`);
+  await fs.access(fileLocation).catch(() => { throw "❌ That file has been transfered already or never existed."; });
+  return fs.copy(fileLocation, resolve(clientDir, `${type}s`, `${name}.js`))
     .then(() => {
       reload[type].call(client.funcs, `${name}`).catch((response) => { throw `❌ ${response}`; });
       return msg.sendMessage(`✅ Successfully Transferred ${type}: ${name}`);

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,3 +1,3 @@
 exports.run = (client, guild) => {
-  if (guild.available) client.settingGateway.create(guild);
+  if (guild.available) client.settingGateway.create(guild).catch(e => client.emit("log", e, "error"));
 };

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,3 +1,3 @@
 exports.run = (client, guild) => {
-  if (guild.available) client.settingGateway.destroy(guild.id);
+  if (guild.available) client.settingGateway.destroy(guild.id).catch(() => null);
 };

--- a/index.js
+++ b/index.js
@@ -10,4 +10,5 @@ module.exports = {
   SettingsGateway: require("./classes/settingGateway"),
   CacheManager: require("./classes/cacheManager"),
   SchemaManager: require("./classes/schemaManager"),
+  SQL: require("./classes/sql"),
 };

--- a/index.js
+++ b/index.js
@@ -11,4 +11,5 @@ module.exports = {
   CacheManager: require("./classes/cacheManager"),
   SchemaManager: require("./classes/schemaManager"),
   SQL: require("./classes/sql"),
+  settingResolver: require("./classes/settingResolver"),
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "homepage": "https://github.com/dirigeants/komada#readme",
   "bugs": {

--- a/providers/json.js
+++ b/providers/json.js
@@ -1,4 +1,4 @@
-const { sep, resolve } = require("path");
+const { resolve } = require("path");
 const fs = require("fs-nextra");
 
 let baseDir;
@@ -15,14 +15,14 @@ exports.init = (client) => {
  * @param {string} table The name of the table you want to check.
  * @returns {Promise<boolean>}
  */
-exports.hasTable = table => fs.pathExists(baseDir + sep + table);
+exports.hasTable = table => fs.pathExists(resolve(baseDir, table));
 
 /**
  * Creates a new directory.
  * @param {string} table The name for the new directory.
  * @returns {Promise<Void>}
  */
-exports.createTable = table => fs.mkdir(baseDir + sep + table);
+exports.createTable = table => fs.mkdir(resolve(baseDir, table));
 
 /**
  * Recursively deletes a directory.
@@ -30,7 +30,7 @@ exports.createTable = table => fs.mkdir(baseDir + sep + table);
  * @returns {Promise<Void>}
  */
 exports.deleteTable = table => this.hasTable(table)
-  .then(exists => (exists ? fs.emptyDir(baseDir + sep + table).then(() => fs.remove(baseDir + sep + table)) : null));
+  .then(exists => (exists ? fs.emptyDir(resolve(baseDir, table)).then(() => fs.remove(resolve(baseDir, table))) : null));
 
 /* Document methods */
 
@@ -40,9 +40,9 @@ exports.deleteTable = table => this.hasTable(table)
  * @returns {Promise<Object[]>}
  */
 exports.getAll = (table) => {
-  const dir = baseDir + sep + table + sep;
+  const dir = resolve(baseDir, table);
   return fs.readdir(dir)
-    .then(files => Promise.all(files.map(file => fs.readJSON(dir + file))));
+    .then(files => Promise.all(files.map(file => fs.readJSON(resolve(dir, file)))));
 };
 
 /**
@@ -51,7 +51,7 @@ exports.getAll = (table) => {
  * @param {string} document The document name.
  * @returns {Promise<?Object>}
  */
-exports.get = (table, document) => fs.readJSON(`${baseDir + sep + table + sep + document}.json`).catch(() => null);
+exports.get = (table, document) => fs.readJSON(resolve(baseDir, table, `${document}.json`)).catch(() => null);
 
 /**
  * Get a random document from a directory.
@@ -67,7 +67,9 @@ exports.getRandom = table => this.getAll(table).then(data => data[Math.floor(Mat
  * @param {Object} data The object with all properties you want to insert into the document.
  * @returns {Promise<Void>}
  */
-exports.create = (table, document, data) => fs.outputJSON(`${baseDir + sep + table + sep + document}.json`, Object.assign(data, { id: document }));
+exports.create = (table, document, data) => fs.outputJSON(resolve(baseDir, table, `${document}.json`), Object.assign(data, { id: document }));
+exports.set = (...args) => this.create(...args);
+exports.insert = (...args) => this.create(...args);
 
 /**
  * Update a document from a directory.
@@ -77,7 +79,7 @@ exports.create = (table, document, data) => fs.outputJSON(`${baseDir + sep + tab
  * @returns {Promise<Void>}
  */
 exports.update = (table, document, data) => this.get(table, document)
-  .then(current => fs.outputJSON(`${baseDir + sep + table + sep + document}.json`, Object.assign(current, data)));
+  .then(current => fs.outputJSON(resolve(baseDir, table, `${document}.json`), Object.assign(current, data)));
 
 /**
  * Replace all the data from a document.
@@ -86,7 +88,7 @@ exports.update = (table, document, data) => this.get(table, document)
  * @param {Object} data The new data for the document.
  * @returns {Promise<Void>}
  */
-exports.replace = (table, document, data) => fs.outputJSON(`${baseDir + sep + table + sep + document}.json`, data);
+exports.replace = (table, document, data) => fs.outputJSON(resolve(baseDir, table, `${document}.json`), data);
 
 /**
  * Delete a document from the table.
@@ -94,7 +96,7 @@ exports.replace = (table, document, data) => fs.outputJSON(`${baseDir + sep + ta
  * @param {string} document The document name.
  * @returns {Promise<Void>}
  */
-exports.delete = (table, document) => fs.unlink(`${baseDir + sep + table + sep + document}.json`);
+exports.delete = (table, document) => fs.unlink(resolve(baseDir, table, `${document}.json`));
 
 exports.conf = {
   moduleName: "json",

--- a/providers/json.js
+++ b/providers/json.js
@@ -4,6 +4,7 @@ const fs = require("fs-nextra");
 let baseDir;
 
 exports.init = (client) => {
+  if (baseDir) return null;
   baseDir = resolve(client.clientBaseDir, "bwd", "provider", "json");
   return fs.ensureDir(baseDir).catch(err => client.emit("log", err, "error"));
 };
@@ -52,6 +53,16 @@ exports.getAll = (table) => {
  * @returns {Promise<?Object>}
  */
 exports.get = (table, document) => fs.readJSON(resolve(baseDir, table, `${document}.json`)).catch(() => null);
+
+/**
+ * Check if the document exists.
+ * @param {string} table The name of the directory.
+ * @param {string} document The document name.
+ * @returns {Promise<boolean>}
+ */
+exports.has = (table, document) => fs.access(resolve(baseDir, table, `${document}.json`))
+  .then(() => true)
+  .catch(() => false);
 
 /**
  * Get a random document from a directory.

--- a/providers/json.js
+++ b/providers/json.js
@@ -60,9 +60,7 @@ exports.get = (table, document) => fs.readJSON(resolve(baseDir, table, `${docume
  * @param {string} document The document name.
  * @returns {Promise<boolean>}
  */
-exports.has = (table, document) => fs.access(resolve(baseDir, table, `${document}.json`))
-  .then(() => true)
-  .catch(() => false);
+exports.has = (table, document) => fs.pathExists(resolve(baseDir, table, `${document}.json`));
 
 /**
  * Get a random document from a directory.


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
This PR was supposed to be Patch, fixing a racecondition, but ended fixing everything else. So... Minor?

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fix ratecondition (providers now load before settingGateway).
- Better path resolving.
- SQL Compatibility.
- SQL property for Schema.
- getResolved method ( by @bdistin ) which returns the resolved configuration from a Guild.
- Better type parsing.
- settingResolver class.
- SQL class.
- `schema` getter for SettingGateway, as a shortcut of `SettingGateway.SchemaManager.schema`.
- `schemaManager` getter for Client, as a shortcut of `Client.SettingGateway.SchemaManager`.
- Better error catching at events.
- Added `SQL` and `settingResolver` to `index.js`.
- If the bot was unable to send a message, the `reboot` command would never call `process.exit()`.
- Beautified the `$conf list` command. Now it has the format from the `help` command.

### (If Applicable) What Issue does it fix?
 
- Raceconditions (Functions initing before Providers and SettingGateway).
- SQL Compatibility in the NoSQL Environment from SettingGateway.
- A few Unhandled Promise Errors.

### Testing

- [x] SQLite Compatibility.
- [x] SQL Schema Type Builder.
- [x] Conf command.
- [x] Array type (NoSQL).
- [x] Array type (SQL).

### Version bumped to: 0.20.3
