### PR TITLE
Fix Reloading Commands

### DIFF
--- a/classes/loader.js
+++ b/classes/loader.js
@@ -157,7 +157,7 @@ module.exports = class Loader {
     const file = fullCommand ? [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`] : `${name}.js`.split(sep);
     const fileToCheck = file[file.length - 1];
     const dirToCheck = resolve(dir, ...file.slice(0, -1));
-    const files = await fs.readdir(dirToCheck);
+    const files = await fs.readdir(dirToCheck).catch(() => { throw `Client Core commands cannot be reloaded.`; });
     if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file}`;
     this.client.aliases.forEach((cmd, alias) => {
       if (cmd === name) this.client.aliases.delete(alias);

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -157,8 +157,8 @@ module.exports = class Loader {
     const file = fullCommand ? [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`] : `${name}.js`.split(sep);
     const fileToCheck = file[file.length - 1];
     const dirToCheck = resolve(dir, ...file.slice(0, -1));
-    const files = await fs.readdir(dirToCheck).catch(() => { throw `Client Core commands cannot be reloaded.`; });
-    if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file}`;
+    const files = await fs.readdir(dirToCheck).catch(() => { throw `Client core commands cannot be reloaded.`; });
+    if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file.join(sep)}`;
     this.client.aliases.forEach((cmd, alias) => {
       if (cmd === name) this.client.aliases.delete(alias);
     });

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -157,7 +157,7 @@ module.exports = class Loader {
     const file = fullCommand ? [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`] : `${name}.js`.split(sep);
     const fileToCheck = file[file.length - 1];
     const dirToCheck = resolve(dir, ...file.slice(0, -1));
-    const files = await fs.readdir(dirToCheck).catch(() => { throw `A user directory path could not be found. Only user commands may be reloaded.`; });
+    const files = await fs.readdir(dirToCheck).catch(() => { throw "A user directory path could not be found. Only user commands may be reloaded."; });
     if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file.join(sep)}`;
     this.client.aliases.forEach((cmd, alias) => {
       if (cmd === name) this.client.aliases.delete(alias);

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -159,7 +159,7 @@ module.exports = class Loader {
     if (fullCommand) {
       file = `${fullCommand.help.fullCategory.length !== 0 ? `${fullCommand.help.fullCategory.join(sep)}${sep}` : ""}${fullCommand.help.name}.js`;
       fileToCheck = file.split(sep)[file.split(sep).length - 1];
-      dirToCheck = resolve(dir, fullCommand.help.fullCategory ? `${fullCommand.help.fullCategory.join(sep)}${sep}` : "");
+      dirToCheck = resolve(dir, fullCommand.help.fullCategory ? `${fullCommand.help.fullCategory.join(sep)}` : "");
     } else {
       file = `${name}.js`;
       fileToCheck = file.split(sep)[file.split(sep).length - 1];
@@ -172,7 +172,8 @@ module.exports = class Loader {
     });
     await this.loadFiles([file], dir, this.loadNewCommand, this.reloadCommand)
       .catch((err) => { throw err; });
-    if (this.client.commands.get(name.split(sep)[name.split(sep).length - 1]).init) this.client.commands.get(name.split(sep)[name.split(sep).length - 1]).init(this.client);
+    const newCommand = this.client.commands.get(name.split(sep)[name.split(sep).length - 1]) || this.client.commands.get(this.client.aliases.get(name.split(sep)[name.split(sep).length - 1]));
+    if (newCommand.init) newCommand.init(this.client);
     return `Successfully reloaded the command ${name}.`;
   }
 

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -159,7 +159,7 @@ module.exports = class Loader {
     if (fullCommand) {
       file = `${fullCommand.help.fullCategory.length !== 0 ? `${fullCommand.help.fullCategory.join(sep)}${sep}` : ""}${fullCommand.help.name}.js`;
       fileToCheck = file.split(sep)[file.split(sep).length - 1];
-      dirToCheck = resolve(dir, fullCommand.help.fullCategory ? `${fullCommand.help.fullCategory.join(sep)}` : "");
+      dirToCheck = resolve(dir, ...fullCommand.help.fullCategory);
     } else {
       file = `${name}.js`;
       fileToCheck = file.split(sep)[file.split(sep).length - 1];

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -157,7 +157,7 @@ module.exports = class Loader {
     const file = fullCommand ? [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`] : `${name}.js`.split(sep);
     const fileToCheck = file[file.length - 1];
     const dirToCheck = resolve(dir, ...file.slice(0, -1));
-    const files = await fs.readdir(dirToCheck).catch(() => { throw `Client core commands cannot be reloaded.`; });
+    const files = await fs.readdir(dirToCheck).catch(() => { throw `A user directory path could not be found. Only user commands may be reloaded.`; });
     if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file.join(sep)}`;
     this.client.aliases.forEach((cmd, alias) => {
       if (cmd === name) this.client.aliases.delete(alias);

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -151,7 +151,7 @@ module.exports = class Loader {
 
   async reloadCommand(name) {
     if (name.endsWith(".js")) name = name.slice(0, -3);
-    name = join(name.split("/"));
+    name = join(...name.split("/"));
     const fullCommand = this.client.commands.get(name) || this.client.commands.get(this.client.aliases.get(name));
     const dir = this.clientDirs.commands;
     let file;

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -111,6 +111,7 @@ module.exports = class Loader {
     if (!files) return false;
     await this.loadFiles(files.filter(file => file.endsWith(".js")
       && (coreProtected.commands.includes(file.split(".")[0]) || !this.client.config.disabled.commands.includes(file.split(".")[0])))
+      .map(file => [file])
       , dir, this.loadNewCommand, this.loadCommands)
       .catch((err) => { throw err; });
     const subfolders = [];

--- a/classes/loader.js
+++ b/classes/loader.js
@@ -154,18 +154,9 @@ module.exports = class Loader {
     name = join(...name.split("/"));
     const fullCommand = this.client.commands.get(name) || this.client.commands.get(this.client.aliases.get(name));
     const dir = this.clientDirs.commands;
-    let file;
-    let fileToCheck;
-    let dirToCheck;
-    if (fullCommand) {
-      file = [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`];
-      fileToCheck = file.split(sep)[file.split(sep).length - 1];
-      dirToCheck = resolve(dir, ...fullCommand.help.fullCategory);
-    } else {
-      file = `${name}.js`.split(sep);
-      fileToCheck = file[file.length - 1];
-      dirToCheck = resolve(dir, ...file.slice(0, -1));
-    }
+    const file = fullCommand ? [...fullCommand.help.fullCategory, `${fullCommand.help.name}.js`] : `${name}.js`.split(sep);
+    const fileToCheck = file[file.length - 1];
+    const dirToCheck = resolve(dir, ...file.slice(0, -1));
     const files = await fs.readdir(dirToCheck);
     if (!files.includes(fileToCheck)) throw `Could not find a reloadable file named ${file}`;
     this.client.aliases.forEach((cmd, alias) => {

--- a/commands/System/stats.js
+++ b/commands/System/stats.js
@@ -1,7 +1,7 @@
 const { version: discordVersion } = require("discord.js");
 const moment = require("moment");
 require("moment-duration-format");
-const { version: komadaVersion } = require("../../index.js");
+const { version: komadaVersion } = require("komada");
 
 exports.run = async (client, msg) => {
   const duration = moment.duration(client.uptime).format(" D [days], H [hrs], m [mins], s [secs]");


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixes an issue with reloading commands that would make the path.resolve go to your local drive due to an extra sep at the end of the path. Path already joins the strings together with seperators, so there's no reason to add them on yourself.
- Also preemptively fixes the init of a reloaded command where the command that was reloaded was reloaded using an alias as opposed to the actual command name
-


### (If Applicable) What Issue does it fix?
 Fixes... ditto
