### PR TITLE
Abstraction of Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ command.
 
 ### Changed
 - [[#300](https://github.com/dirigeants/komada/pull/300)] **[Update]** `client.methods.Embed` changed to use Discord.js MessageEmbed.
+- [[#297](https://github.com/dirigeants/komada/pull/297)] **[Update]** Abstraction of Settings and slight refactor so its easier to use.
 - [[#296](https://github.com/dirigeants/komada/pull/296)] **[Update]** The JSON provider and schemaManager now uses atomics.
 - [[#293](https://github.com/dirigeants/komada/pull/293)] **[Performance]** Faster prefix check and resolve for prefixes
 stored inside an Array.

--- a/classes/GuildSettings.js
+++ b/classes/GuildSettings.js
@@ -1,0 +1,7 @@
+const SettingGateway = require("./SettingGateway");
+
+module.exports = class GuildSettings extends SettingGateway {
+  constructor() {
+    super();
+  }
+};

--- a/classes/GuildSettings.js
+++ b/classes/GuildSettings.js
@@ -1,7 +1,47 @@
-const SettingGateway = require("./SettingGateway");
+const SettingGateway = require("./settingGateway");
 
 module.exports = class GuildSettings extends SettingGateway {
-  constructor() {
-    super();
+  constructor(client) {
+    super(client, "guilds");
+  }
+
+  async validate(guild) {
+    const result = await this.resolver.guild(guild);
+    if (!result) throw "The parameter <Guild> expects either a Guild ID or a Guild Object.";
+    return result;
+  }
+
+  /**
+   * Get the default DataSchema from Komada.
+   * @readonly
+   * @returns {Object}
+   */
+  get defaultDataSchema() {
+    return {
+      prefix: {
+        type: "String",
+        default: this.client.config.prefix,
+        array: false,
+        sql: `TEXT NOT NULL DEFAULT '${this.client.config.prefix}'`,
+      },
+      modRole: {
+        type: "Role",
+        default: null,
+        array: false,
+        sql: "TEXT",
+      },
+      adminRole: {
+        type: "Role",
+        default: null,
+        array: false,
+        sql: "TEXT",
+      },
+      disabledCommands: {
+        type: "Command",
+        default: [],
+        array: true,
+        sql: "TEXT DEFAULT '[]'",
+      },
+    };
   }
 };

--- a/classes/cacheManager.js
+++ b/classes/cacheManager.js
@@ -6,21 +6,21 @@ module.exports = class CacheManager {
 
   get(guild) {
     if (this.cacheEngine === "js") return this.data.get(guild);
-    return this.data.get("guilds", guild);
+    return this.data.get(this.type, guild);
   }
 
   getAll() {
     if (this.cacheEngine === "js") return this.data;
-    return this.data.getAll("guilds");
+    return this.data.getAll(this.type);
   }
 
   set(guild, data) {
     if (this.cacheEngine === "js") return this.data.set(guild, data);
-    return this.data.set("guilds", guild, data);
+    return this.data.set(this.type, guild, data);
   }
 
   delete(guild) {
     if (this.cacheEngine === "js") return this.data.delete(guild);
-    return this.data.delete("guilds", guild);
+    return this.data.delete(this.type, guild);
   }
 };

--- a/classes/client.js
+++ b/classes/client.js
@@ -5,7 +5,7 @@ const CommandMessage = require("./commandMessage");
 const Loader = require("./loader");
 const ArgResolver = require("./argResolver");
 const PermLevels = require("./permLevels");
-const GuildSettings = require("./GuildSettings");
+const GuildSettings = require("./guildSettings");
 
 const defaultPermStructure = new PermLevels()
   .addLevel(0, false, () => true)

--- a/classes/client.js
+++ b/classes/client.js
@@ -5,7 +5,7 @@ const CommandMessage = require("./commandMessage");
 const Loader = require("./loader");
 const ArgResolver = require("./argResolver");
 const PermLevels = require("./permLevels");
-const SettingGateway = require("./settingGateway");
+const GuildSettings = require("./GuildSettings");
 
 const defaultPermStructure = new PermLevels()
   .addLevel(0, false, () => true)
@@ -67,7 +67,7 @@ module.exports = class Komada extends Discord.Client {
       escapeMarkdown: Discord.escapeMarkdown,
       splitMessage: Discord.splitMessage,
     };
-    this.settingGateway = new SettingGateway(this);
+    this.settingGateway = new GuildSettings(this);
     this.application = null;
     this.once("ready", this._ready.bind(this));
   }

--- a/classes/parsedUsage.js
+++ b/classes/parsedUsage.js
@@ -11,7 +11,7 @@ module.exports = class ParsedUsage {
   }
 
   fullUsage(msg) {
-    const prefix = msg.guildSettings.prefix || client.config.prefix;
+    const prefix = msg.guildSettings.prefix || this.client.config.prefix;
     return `${prefix.length !== 1 ? `${prefix} ` : prefix}${this.nearlyFullUsage}`;
   }
 

--- a/classes/parsedUsage.js
+++ b/classes/parsedUsage.js
@@ -11,7 +11,7 @@ module.exports = class ParsedUsage {
   }
 
   fullUsage(msg) {
-    const prefix = msg.guildSettings.prefix;
+    const prefix = msg.guildSettings.prefix || client.config.prefix;
     return `${prefix.length !== 1 ? `${prefix} ` : prefix}${this.nearlyFullUsage}`;
   }
 

--- a/classes/schemaManager.js
+++ b/classes/schemaManager.js
@@ -30,13 +30,6 @@ class SchemaManager extends CacheManager {
    * @returns {void}
    */
   validateSchema(schema) {
-    if (!("prefix" in schema)) {
-      this.client.emit("log", "The key 'prefix' is obligatory", "error");
-      schema.prefix = {
-        type: "String",
-        default: this.client.config.prefix,
-      };
-    }
     for (const [key, value] of Object.entries(schema)) { // eslint-disable-line no-restricted-syntax
       if (value instanceof Object && "type" in value && "default" in value) {
         if (value.array && !(value.default instanceof Array)) {
@@ -91,7 +84,6 @@ class SchemaManager extends CacheManager {
    * @returns {void}
    */
   remove(key, force = false) {
-    if (key === "prefix") throw "You can't remove the prefix key.";
     delete this.schema[key];
     if (force) this.force("delete", key);
     return fs.outputJSON(this.filePath, this.schema);

--- a/classes/schemaManager.js
+++ b/classes/schemaManager.js
@@ -112,11 +112,11 @@ class SchemaManager extends CacheManager {
     return this.sync();
   }
 
-/**
-  * Return a blank object if no default is set.
-  * @readonly
-  */
-  get defaultDataSchema() {
+  /**
+   * Return a blank object if no default is set.
+   * @readonly
+   */
+  get defaultDataSchema() { // eslint-disable-line 
     return {};
   }
 }

--- a/classes/schemaManager.js
+++ b/classes/schemaManager.js
@@ -17,7 +17,7 @@ class SchemaManager {
   async init() {
     const baseDir = resolve(this.client.clientBaseDir, "bwd");
     await fs.ensureDir(baseDir);
-    this.filePath = resolve(baseDir, "schema.json");
+    this.filePath = resolve(baseDir, `${this.settingGateway.type}Schema.json`);
     const schema = await fs.readJSON(this.filePath)
       .catch(() => fs.outputJSON(this.filePath, this.defaultDataSchema).then(() => this.defaultDataSchema));
     return this.validate(schema);
@@ -106,14 +106,14 @@ class SchemaManager {
     if (this.settingGateway.sql) {
       await this.settingGateway.sql.updateColumns(this.schema, this.defaults, key);
     }
-    const data = this.settingGateway.getAll("guilds");
+    const data = this.settingGateway.getAll(this.settingGateway.type);
     let value;
     if (action === "add") value = this.defaults[key];
     await Promise.all(data.map(async (obj) => {
       const object = obj;
       if (action === "delete") delete object[key];
       else object[key] = value;
-      if (obj.id) await this.client.settingGateway.provider.replace("guilds", obj.id, object);
+      if (obj.id) await this.client.settingGateway.provider.replace(this.settingGateway.type, obj.id, object);
       return true;
     }));
     return this.settingGateway.sync();
@@ -134,32 +134,7 @@ class SchemaManager {
    * @returns {Object}
    */
   get defaultDataSchema() {
-    return {
-      prefix: {
-        type: "String",
-        default: this.client.config.prefix,
-        array: false,
-        sql: `TEXT NOT NULL DEFAULT '${this.client.config.prefix}'`,
-      },
-      modRole: {
-        type: "Role",
-        default: null,
-        array: false,
-        sql: "TEXT",
-      },
-      adminRole: {
-        type: "Role",
-        default: null,
-        array: false,
-        sql: "TEXT",
-      },
-      disabledCommands: {
-        type: "Command",
-        default: [],
-        array: true,
-        sql: "TEXT DEFAULT '[]'",
-      },
-    };
+    return this.settingGateway.defaultDataSchema;
   }
 }
 

--- a/classes/schemaManager.js
+++ b/classes/schemaManager.js
@@ -119,6 +119,14 @@ class SchemaManager extends CacheManager {
     }));
     return this.sync();
   }
+
+/**
+  * Return a blank object if no default is set.
+  * @readonly
+  */
+  get defaultDataSchema() {
+    return {};
+  }
 }
 
 module.exports = SchemaManager;

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -20,7 +20,7 @@ module.exports = class SettingGateway extends SchemaManager {
   }
 
   /**
-   * Initialize the configuration for all Guilds.
+   * Initialize the configuration for this gateway.
    * @returns {void}
    */
   async init() {
@@ -41,34 +41,34 @@ module.exports = class SettingGateway extends SchemaManager {
   }
 
   /**
-   * Create a new Guild entry for the configuration.
-   * @param {Guild|Snowflake} guild The Guild object or snowflake.
+   * Create a new entry in the configuration.
+   * @param {Object|string} input An object containing a id property, like discord.js objects, or a string.
    * @returns {void}
    */
-  async create(guild) {
-    const target = await this.validate(guild);
-    await this.provider.create(this.type, target.id, this.defaults);
-    super.set(target.id, this.defaults);
+  async create(input) {
+    const target = await this.validate(input).then(output => (output.id || output));
+    await this.provider.create(this.type, target, this.defaults);
+    super.set(target, this.defaults);
   }
 
   /**
-   * Remove a Guild entry from the configuration.
-   * @param {Snowflake} guild The Guild object or snowflake.
+   * Remove an entry from the configuration.
+   * @param {string} input A key to delete from the cache.
    * @returns {void}
    */
-  async destroy(guild) {
-    await this.provider.delete(this.type, guild);
-    super.delete(this.type, guild);
+  async destroy(input) {
+    await this.provider.delete(this.type, input);
+    super.delete(this.type, input);
   }
 
   /**
-   * Get a Guild entry from the configuration.
-   * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
+   * Get an entry from the cache.
+   * @param {string} input A key to get the value for.
    * @returns {Object}
    */
-  get(guild) {
-    if (guild === "default") return this.defaults;
-    return super.get(guild) || this.defaults;
+  get(input) {
+    if (input === "default") return this.defaults;
+    return super.get(input) || this.defaults;
   }
 
   /**
@@ -87,83 +87,83 @@ module.exports = class SettingGateway extends SchemaManager {
   }
 
   /**
-   * Sync either all Guild entries from the configuration, or a single one.
-   * @param {(Guild|Snowflake)} [guild=null] The configuration for the selected Guild, if specified.
+   * Sync either all entries from the configuration, or a single one.
+   * @param {Object|string} [input=null] An object containing a id property, like discord.js objects, or a string.
    * @returns {void}
    */
-  async sync(guild = null) {
-    if (!guild) {
+  async sync(input = null) {
+    if (!input) {
       const data = await this.provider.getAll(this.type);
       if (this.sql) for (let i = 0; i < data.length; i++) this.sql.deserializer(data[i]);
       for (const key of data) super.set(key.id, key);
       return;
     }
-    const target = await this.validate(guild);
+    const target = await this.validate(input).then(output => (output.id || output));
     const data = await this.provider.get(this.type, target.id);
     if (this.sql) this.sql.deserializer(data);
-    await super.set(target.id, data);
+    await super.set(target, data);
   }
 
   /**
-   * Reset a key's value to default from a Guild configuration.
-   * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
+   * Reset a key's value to default from a entry.
+   * @param {Object|string} input An object containing a id property, like discord.js objects, or a string.
    * @param {string} key The key to reset.
    * @returns {*}
    */
-  async reset(guild, key) {
-    const target = await this.validate(guild);
+  async reset(input, key) {
+    const target = await this.validate(input).then(output => (output.id || output));
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
     const defaultKey = this.schema[key].default;
-    await this.provider.update(this.type, target.id, { [key]: defaultKey });
-    this.sync(target.id);
+    await this.provider.update(this.type, target, { [key]: defaultKey });
+    this.sync(target);
     return defaultKey;
   }
 
   /**
-   * Update a Guild's configuration.
-   * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
+   * Updates an entry.
+   * @param {Object|string} input An object containing a id property, like discord.js objects, or a string.
    * @param {string} key The key to update.
    * @param {any} data The new value for the key.
    * @returns {any}
    */
-  async update(guild, key, data) {
+  async update(input, key, data) {
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
-    const target = await this.validate(guild);
-    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, target, this.schema[key]);
+    const target = await this.validate(input).then(output => (output.id || output));
+    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, this.client.guilds.get(target), this.schema[key]);
     if (result.id) result = result.id;
-    await this.provider.update(this.type, target.id, { [key]: result });
+    await this.provider.update(this.type, target, { [key]: result });
     await this.sync(target.id);
     return result;
   }
 
   /**
    * Update an array from the a Guild's configuration.
-   * @param {(Guild|Snowflake)} guild The Guild object or snowflake.
+   * @param {Object|string} input An object containing a id property, like discord.js objects, or a string.
    * @param {string} type Either 'add' or 'remove'.
    * @param {string} key The key from the Schema.
    * @param {any} data The value to be added or removed.
    * @returns {boolean}
    */
-  async updateArray(guild, type, key, data) {
+  async updateArray(input, type, key, data) {
     if (!["add", "remove"].includes(type)) throw "The type parameter must be either add or remove.";
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
     if (!this.schema[key].array) throw `The key ${key} is not an Array.`;
     if (data === undefined) throw "You must specify the value to add or filter.";
-    const target = await this.validate(guild);
-    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, target, this.schema[key]);
+    const target = await this.validate(input).then(output => (output.id || output));
+    let result = await this.resolver[this.schema[key].type.toLowerCase()](data, this.client.guilds.get(target), this.schema[key]);
     if (result.id) result = result.id;
-    const cache = this.get(target.id);
+    const cache = this.get(target);
     if (type === "add") {
       if (cache[key].includes(result)) throw `The value ${data} for the key ${key} already exists.`;
       cache[key].push(result);
-      await this.provider.update(this.type, target.id, { [key]: cache[key] });
+      await this.provider.update(this.type, target, { [key]: cache[key] });
       await this.sync(target.id);
       return result;
     }
     if (!cache[key].includes(result)) throw `The value ${data} for the key ${key} does not exist.`;
     cache[key] = cache[key].filter(v => v !== result);
-    await this.provider.update(this.type, target.id, { [key]: cache[key] });
-    await this.sync(target.id);
+    await this.provider.update(this.type, target, { [key]: cache[key] });
+    await this.sync(target);
     return true;
   }
 

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -11,7 +11,7 @@ module.exports = class SettingGateway extends SchemaManager {
     this.client = client;
 
     /** @type {string} */
-    this.type = type;
+    this.type = `${type}_`;
 
     /** @type {string} */
     this.engine = client.config.provider.engine || "json";

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -66,7 +66,7 @@ module.exports = class SettingGateway extends CacheManager {
    * @returns {void}
    */
   async create(guild) {
-    const target = await this.validateGuild(guild);
+    const target = await this.validate(guild);
     await this.provider.create(this.type, target.id, this.schemaManager.defaults);
     super.set(target.id, this.schemaManager.defaults);
   }
@@ -118,7 +118,7 @@ module.exports = class SettingGateway extends CacheManager {
       for (const key of data) super.set(key.id, key);
       return;
     }
-    const target = await this.validateGuild(guild);
+    const target = await this.validate(guild);
     const data = await this.provider.get(this.type, target.id);
     if (this.sql) this.sql.deserializer(data);
     await super.set(target.id, data);
@@ -131,7 +131,7 @@ module.exports = class SettingGateway extends CacheManager {
    * @returns {*}
    */
   async reset(guild, key) {
-    const target = await this.validateGuild(guild);
+    const target = await this.validate(guild);
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
     const defaultKey = this.schema[key].default;
     await this.provider.update(this.type, target.id, { [key]: defaultKey });
@@ -148,7 +148,7 @@ module.exports = class SettingGateway extends CacheManager {
    */
   async update(guild, key, data) {
     if (!(key in this.schema)) throw `The key ${key} does not exist in the current data schema.`;
-    const target = await this.validateGuild(guild);
+    const target = await this.validate(guild);
     let result = await this.resolver[this.schema[key].type.toLowerCase()](data, target, this.schema[key]);
     if (result.id) result = result.id;
     await this.provider.update(this.type, target.id, { [key]: result });

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -27,7 +27,7 @@ module.exports = class SettingGateway extends SchemaManager {
     this.provider = this.client.providers.get(this.engine);
     if (!this.provider) throw `This provider (${this.engine}) does not exist in your system.`;
     await this.initSchema();
-    this.sql = this.provider.conf.sql ? new SQL(this.client, this.provider) : false;
+    this.sql = this.provider.conf.sql ? new SQL(this.client, this, this.provider) : false;
     if (!(await this.provider.hasTable(this.type))) {
       const SQLCreate = this.sql ? this.sql.buildSQLSchema(this.schema) : undefined;
       await this.provider.createTable(this.type, SQLCreate);

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -2,7 +2,7 @@ const SettingResolver = require("./settingResolver");
 const SchemaManager = require("./schemaManager");
 const SQL = require("./sql");
 
-/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-restricted-syntax, class-methods-use-this */
 module.exports = class SettingGateway extends SchemaManager {
   constructor(client, type) {
     super(client);
@@ -165,5 +165,9 @@ module.exports = class SettingGateway extends SchemaManager {
     await this.provider.update(this.type, target.id, { [key]: cache[key] });
     await this.sync(target.id);
     return true;
+  }
+
+  validate(something) {
+    return something;
   }
 };

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -18,7 +18,7 @@ module.exports = class SettingGateway extends CacheManager {
     this.engine = client.config.provider.engine || "json";
 
     this.resolver = new SettingResolver(client);
-    this.schemaManager = new SchemaManager(this.client);
+    this.schemaManager = new SchemaManager(client);
   }
 
   /**

--- a/classes/sql.js
+++ b/classes/sql.js
@@ -10,8 +10,9 @@ const DefaultDataTypes = {
 
 /* eslint-disable no-restricted-syntax */
 class SQL {
-  constructor(client, provider) {
+  constructor(client, gateway, provider) {
     this.client = client;
+    this.gateway = gateway;
     this.provider = provider;
   }
 
@@ -98,7 +99,7 @@ class SQL {
    * @readonly
    */
   get schema() {
-    return this.client.schemaManager.schema;
+    return this.gateway.schema;
   }
 
   /**
@@ -106,7 +107,7 @@ class SQL {
    * @readonly
    */
   get defaults() {
-    return this.client.schemaManager.defaults;
+    return this.gateway.defaults;
   }
 }
 

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -14,7 +14,7 @@ exports.run = async (client, msg, [action, key, ...value]) => {
       if (!key) return msg.sendMessage("You must provide a key");
       if (!value[0]) return msg.sendMessage("You must provide a value");
       if (!configs.id) await client.settingGateway.create(msg.guild);
-      if (client.settingGateway.schemaManager.schema[key].array) {
+      if (client.settingGateway.schema[key].array) {
         await client.settingGateway.updateArray(msg.guild, "add", key, value.join(" "));
         return msg.sendMessage(`Successfully added the value \`${value.join(" ")}\` to the key: **${key}**`);
       }

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -9,7 +9,6 @@ const handle = (value) => {
 
 exports.run = async (client, msg, [action, key, ...value]) => {
   const configs = msg.guild.settings;
-  console.log(value);
   switch (action) {
     case "set": {
       if (!key) return msg.sendMessage("You must provide a key");

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -9,7 +9,7 @@ const handle = (value) => {
 
 exports.run = async (client, msg, [action, key, ...value]) => {
   const configs = msg.guild.settings;
-
+  console.log(value);
   switch (action) {
     case "set": {
       if (!key) return msg.sendMessage("You must provide a key");
@@ -71,6 +71,6 @@ exports.conf = {
 exports.help = {
   name: "conf",
   description: "Define per-server configuration.",
-  usage: "<set|get|reset|list|remove> [key:string] [value:string]",
+  usage: "<set|get|reset|list|remove> [key:string] [value:string] [...]",
   usageDelim: " ",
 };

--- a/commands/System/help.js
+++ b/commands/System/help.js
@@ -56,7 +56,7 @@ exports.buildHelp = (client, msg) => {
       const subcat = command.help.subCategory;
       if (!help.hasOwnProperty(cat)) help[cat] = {};
       if (!help[cat].hasOwnProperty(subcat)) help[cat][subcat] = [];
-      help[cat][subcat].push(`${msg.guildSettings.prefix}${command.help.name.padEnd(longest)} :: ${command.help.description}`);
+      help[cat][subcat].push(`${msg.guildSettings.prefix || client.config.prefix}${command.help.name.padEnd(longest)} :: ${command.help.description}`);
     }
   }
 

--- a/commands/System/help.js
+++ b/commands/System/help.js
@@ -46,6 +46,7 @@ exports.help = {
 /* eslint-disable no-restricted-syntax, no-prototype-builtins */
 exports.buildHelp = (client, msg) => {
   const help = {};
+  const prefix = msg.guildSettings.prefix || client.config.prefix;
 
   const commandNames = Array.from(client.commands.keys());
   const longest = commandNames.reduce((long, str) => Math.max(long, str.length), 0);
@@ -56,7 +57,7 @@ exports.buildHelp = (client, msg) => {
       const subcat = command.help.subCategory;
       if (!help.hasOwnProperty(cat)) help[cat] = {};
       if (!help[cat].hasOwnProperty(subcat)) help[cat][subcat] = [];
-      help[cat][subcat].push(`${msg.guildSettings.prefix || client.config.prefix}${command.help.name.padEnd(longest)} :: ${command.help.description}`);
+      help[cat][subcat].push(`${prefix}${command.help.name.padEnd(longest)} :: ${command.help.description}`);
     }
   }
 

--- a/functions/getPrefix.js
+++ b/functions/getPrefix.js
@@ -1,6 +1,6 @@
 module.exports = async (client, msg) => {
   if (client.config.prefixMention.test(msg.content)) return client.config.prefixMention;
-  const { prefix } = msg.guildSettings;
+  const prefix = msg.guildSettings.prefix || client.config.prefix;
   const { regExpEsc } = client.funcs;
   if (prefix instanceof Array) {
     for (let i = prefix.length - 1; i >= 0; i--) {


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch (might be minor depending on the output of this)

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

The new settings by @kyranet work wonderfully. People have come to like them very much and I'm pleased with how they turned up. But the way he set it up doesn't let you efficiently edit it to use settings for whatever you want, without having to hard-code a lot of the methods just to change one or two things. This PR will aim to abstract the class more, and differentiate between a "interface" and "Guild Settings". SettingsGateway should be an interface, not the final product. This will allow you to require komada and extend the Gateway for whatever your purposes might be.
