### PR TITLE
OwnerID Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - Classbased | Staged for 0.20.3
 ### Added
+- [[#298](https://github.com/dirigeants/komada/pull/298)] `config.ownerID` is automatically detected now.
 - [[#291](https://github.com/dirigeants/komada/pull/291)] `getResolved` method, which returns the resolved configuration
 from a Guild.
 - [[#289](https://github.com/dirigeants/komada/pull/289)] Added SQL compatibility.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ client.login("your-bot-token");
 
 - **botToken**: The MFA token for your bot. To get this, please see [This discord.js Getting Started Guide](https://anidiotsguide.gitbooks.io/discord-js-bot-guide/getting-started/the-long-version.html), which explains how to create the bot and get the token.
 - **ownerID**: The User ID of the bot owner - you. This gives you the highest possible access to the bot's default commands, including eval! To obtain it, enable Developer Mode in Discord, right-click your name and do "Copy ID".
+
+> As of Komada 0.20.4, the owner of the bot/application is automatically fetched for you. Supplying this option will no longer do anything.
+
 - **prefix**: The default prefix when the bot first boots up. This option becomes useless after first boot, since the prefix is written to the default configuration system.
 - **clientOptions**: These are passed directly to the discord.js library. They are optional. For more information on which options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions).
 - **permStructure**: It allows you to configure the permission levels from Komada, with a range of 0-10. You can also use `Komada.PermLevels` constructor.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client.login("your-bot-token");
 - **botToken**: The MFA token for your bot. To get this, please see [This discord.js Getting Started Guide](https://anidiotsguide.gitbooks.io/discord-js-bot-guide/getting-started/the-long-version.html), which explains how to create the bot and get the token.
 - **ownerID**: The User ID of the bot owner - you. This gives you the highest possible access to the bot's default commands, including eval! To obtain it, enable Developer Mode in Discord, right-click your name and do "Copy ID".
 
-> As of Komada 0.20.4, the owner of the bot/application is automatically fetched for you. Supplying this option will no longer do anything.
+> As of Komada 0.20.4, If you do not set this option, the ownerID will default the creator of the application on the discord developer website.
 
 - **prefix**: The default prefix when the bot first boots up. This option becomes useless after first boot, since the prefix is written to the default configuration system.
 - **clientOptions**: These are passed directly to the discord.js library. They are optional. For more information on which options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ client.login("your-bot-token");
 - **botToken**: The MFA token for your bot. To get this, please see [This discord.js Getting Started Guide](https://anidiotsguide.gitbooks.io/discord-js-bot-guide/getting-started/the-long-version.html), which explains how to create the bot and get the token.
 - **ownerID**: The User ID of the bot owner - you. This gives you the highest possible access to the bot's default commands, including eval! To obtain it, enable Developer Mode in Discord, right-click your name and do "Copy ID".
 
-> As of Komada 0.20.4, If you do not set this option, the ownerID will default the creator of the application on the discord developer website.
+> As of Komada 0.20.4, If you do not set this option, the ownerID will default the creator of the application on the discord developer website. This only works if your bot is not a self/user bot.
 
 - **prefix**: The default prefix when the bot first boots up. This option becomes useless after first boot, since the prefix is written to the default configuration system.
 - **clientOptions**: These are passed directly to the discord.js library. They are optional. For more information on which options are available, see [ClientOptions in the discord.js docs](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions).

--- a/classes/client.js
+++ b/classes/client.js
@@ -103,6 +103,7 @@ module.exports = class Komada extends Discord.Client {
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();
+    this.config.ownerID = this.application.owner.id;
     await Promise.all(this.providers.map((piece) => {
       if (piece.init) return piece.init(this);
       return true;

--- a/classes/client.js
+++ b/classes/client.js
@@ -103,7 +103,7 @@ module.exports = class Komada extends Discord.Client {
   async _ready() {
     this.config.prefixMention = new RegExp(`^<@!?${this.user.id}>`);
     if (this.user.bot) this.application = await super.fetchApplication();
-    this.config.ownerID = this.application.owner.id;
+    if (this.application && !this.config.ownerID) this.config.ownerID = this.application.owner.id;
     await Promise.all(this.providers.map((piece) => {
       if (piece.init) return piece.init(this);
       return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "homepage": "https://github.com/dirigeants/komada#readme",
   "bugs": {


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Change ownerID to be used by the oAuths application owner.
- We already fetch the application for `client.invite`, so there's no reason we can't automatically set the owner for the bot from that.

Edit: You can overwrite this setting by setting it manually, and you will have to set it manually if you plan on using Komada for a selfbot.
