### PR TITLE
[Breaking] Better SG parsing and sync bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - Classbased | Staged for 0.20.3
+## [Unreleased] - Classbased | Staged for 0.20.6
 ### Added
 - [[#322](https://github.com/dirigeants/komada/pull/322)] SettingGateway is now capable to handle asynchronous cache for internal parsing.
 - [[#313](https://github.com/dirigeants/komada/pull/317)] Added `client.settings`, to handle multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - Classbased | Staged for 0.20.3
 ### Added
+- [[#322](https://github.com/dirigeants/komada/pull/322)] SettingGateway is now capable to handle asynchronous cache for internal parsing.
 - [[#313](https://github.com/dirigeants/komada/pull/317)] Added `client.settings`, to handle multiple
 instances of SettingGateway.
 - [[#317](https://github.com/dirigeants/komada/pull/317)] `client.owner` is now a thing.
@@ -67,7 +68,9 @@ keyword. `exports.run = __async__ (client, msg, [...args])`.
 command.
 
 ### Changed
-- [[#313](https://github.com/dirigeants/komada/pull/317)] **[BREAKING]** `client.settingGateway` has been changed to 
+- [[#322](https://github.com/dirigeants/komada/pull/322)] **[BREAKING]** `SettingGateway#update`'s arguments are now `key`, `object` and `?guild`, allowing instances of SG which resolver aimed to non-Guild classes to parse correctly. The argument `object` can contain multiple keys. (So SG will update all keys from the object at once). Previously, you could update only a pair `key-value`.
+- [[#322](https://github.com/dirigeants/komada/pull/322)] Safer editing when using SettingGateway, now ensuring the settings has been created before inserting the data. (Fixes an issue when the data was inserted without creating it before).
+- [[#317](https://github.com/dirigeants/komada/pull/317)] **[BREAKING]** `client.settingGateway` has been changed to 
 `client.settings`, which is able to handle multiple instances of SettingGateway.
 - [[#300](https://github.com/dirigeants/komada/pull/300)] **[Update]** `client.methods.Embed` changed to use Discord.js MessageEmbed.
 - [[#297](https://github.com/dirigeants/komada/pull/297)] **[Update]** Abstraction of Settings and slight refactor so its easier to use.
@@ -123,6 +126,8 @@ core event.
 cached an implied permissions object, instead of generating a new object every time a command is run.
 
 ### Fixed
+- [[#322](https://github.com/dirigeants/komada/pull/322)] **[BugFix]** `SettingGateway#sync` not being running properly.
+- [[#322](https://github.com/dirigeants/komada/pull/322)] **[BugFix]** Settings not being created properly.
 - [[#290](https://github.com/dirigeants/komada/pull/290)] **[BugFix]** Fixed reload commands.
 - [[#289](https://github.com/dirigeants/komada/pull/289)] **[BugFix]** If the bot was unable to send a message, the
 **reboot** command would never call `process.exit()`.

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -171,7 +171,8 @@ module.exports = class SettingGateway extends SchemaManager {
     const target = await this.validate(input).then(output => (output.id || output));
     let result = await this.resolver[this.schema[key].type.toLowerCase()](data, this.client.guilds.get(target), this.schema[key]);
     if (result.id) result = result.id;
-    const cache = this.get(target);
+    let cache = this.get(target);
+    if (cache instanceof Promise) cache = await cache;
     if (type === "add") {
       if (cache[key].includes(result)) throw `The value ${data} for the key ${key} already exists.`;
       cache[key].push(result);

--- a/classes/settingGateway.js
+++ b/classes/settingGateway.js
@@ -81,7 +81,8 @@ module.exports = class SettingGateway extends SchemaManager {
    */
   async getResolved(guild) {
     guild = await this.validate(guild);
-    const settings = this.get(guild.id);
+    let settings = this.get(guild.id);
+    if (settings instanceof Promise) settings = await settings;
     const resolved = await Promise.all(Object.entries(settings).map(([key, data]) => {
       if (this.schema[key] && this.schema[key].array) return { [key]: Promise.all(data.map(entry => this.resolver[this.schema[key].type.toLowerCase()](entry, guild, this.schema[key]))) };
       return { [key]: this.schema[key] && data ? this.resolver[this.schema[key].type.toLowerCase()](data, guild, this.schema[key]) : data };

--- a/commands/System/conf.js
+++ b/commands/System/conf.js
@@ -13,18 +13,16 @@ exports.run = async (client, msg, [action, key, ...value]) => {
     case "set": {
       if (!key) return msg.sendMessage("You must provide a key");
       if (!value[0]) return msg.sendMessage("You must provide a value");
-      if (!configs.id) await client.settings.guilds.create(msg.guild);
       if (client.settings.guilds.schema[key].array) {
         await client.settings.guilds.updateArray(msg.guild, "add", key, value.join(" "));
         return msg.sendMessage(`Successfully added the value \`${value.join(" ")}\` to the key: **${key}**`);
       }
-      const response = await client.settings.guilds.update(msg.guild, key, value.join(" "));
+      const response = await client.settings.guilds.update(msg.guild, { [key]: value.join(" ") });
       return msg.sendMessage(`Successfully updated the key **${key}**: \`${response}\``);
     }
     case "remove": {
       if (!key) return msg.sendMessage("You must provide a key");
       if (!value[0]) return msg.sendMessage("You must provide a value");
-      if (!configs.id) await client.settings.guilds.create(msg.guild);
       if (!client.settings.guilds.schema[key].array) return msg.sendMessage("This key is not array type. Use the action 'reset' instead.");
       return client.settings.guilds.updateArray(msg.guild, "remove", key, value.join(" "))
         .then(() => msg.sendMessage(`Successfully removed the value \`${value.join(" ")}\` from the key: **${key}**`))
@@ -37,7 +35,6 @@ exports.run = async (client, msg, [action, key, ...value]) => {
     }
     case "reset": {
       if (!key) return msg.sendMessage("You must provide a key");
-      if (!configs.id) await client.settings.guilds.create(msg.guild);
       const response = await client.settings.guilds.reset(msg.guild, key);
       return msg.sendMessage(`The key **${key}** has been reset to: \`${response}\``);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "komada",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "Komada: Croatian for 'pieces', is a modular bot system including reloading modules and easy to use custom commands.",
   "homepage": "https://github.com/dirigeants/komada#readme",
   "bugs": {


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
Patch
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Safer editing when using SettingGateway, now ensuring the settings has been created before inserting the data. (Fixes an issue when the data was inserted without creating it before).
- Added support for asynchronous cache into SettingGateway.

### (If Applicable) What Issue does it fix?
- Settings not being created properly.
- Added an extra key in `SettingGateway#update`, so when `this.resolver` aims to a anything but a Guild, it'll be able to parse correctly. (This also improves performance in multikey editing).
