### PR TITLE
Fix Help Command

### DIFF
--- a/src/commands/System/help.js
+++ b/src/commands/System/help.js
@@ -3,6 +3,7 @@ exports.run = async (client, msg, [cmd]) => {
   if (cmd) {
     cmd = client.commands.get(cmd) || client.commands.get(client.aliases.get(cmd));
     if (!cmd) return msg.sendMessage("❌ | Unknown command, please run the help command with no arguments to get a list of them all.");
+    if (!this.runCommandInhibitors(client, msg, cmd)) return; // eslint-disable-line
     const info = [
       `= ${cmd.help.name} = `,
       cmd.help.description,


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
n/a
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Small patch to prevent users from being able to use the help command to see command information for commands they can't use. (QOL fix)
