### PR TITLE
Fix MissingPerms (sort of)

### DIFF
--- a/src/inhibitors/missingBotPermissions.js
+++ b/src/inhibitors/missingBotPermissions.js
@@ -20,6 +20,12 @@ exports.conf = {
 
 exports.run = (client, msg, cmd) => {
   const missing = msg.channel.type === "text" ? msg.channel.permissionsFor(client.user).missing(cmd.conf.botPerms) : impliedPermissions.missing(cmd.conf.botPerms);
-  if (missing.length > 0) return `Insufficient permissions, missing: **${client.funcs.toTitleCase(missing.join(", ").split("_").join(" "))}**`;
+  if (missing.length > 0) {
+    if (missing.includes("READ_MESSAGE_HISTORY") || missing.includes("SEND_MESSAGES")) {
+      client.emit("log", `Unable to View Message history or Send Messages in Channel[${msg.channel.id}](${msg.channel.name})`, "error");
+      return true;
+    }
+    return `Insufficient permissions, missing: **${client.funcs.toTitleCase(missing.join(", ").split("_").join(" "))}**`;
+  }
   return false;
 };

--- a/src/inhibitors/missingBotPermissions.js
+++ b/src/inhibitors/missingBotPermissions.js
@@ -22,7 +22,7 @@ exports.run = (client, msg, cmd) => {
   const missing = msg.channel.type === "text" ? msg.channel.permissionsFor(client.user).missing(cmd.conf.botPerms) : impliedPermissions.missing(cmd.conf.botPerms);
   if (missing.length > 0) {
     if (missing.includes("READ_MESSAGE_HISTORY") || missing.includes("SEND_MESSAGES")) {
-      client.emit("log", `Unable to View Message history or Send Messages in Channel[${msg.channel.id}](${msg.channel.name})`, "error");
+      client.emit("log", `[Channel: ${msg.channel.id}] Insufficient permissions, missing: **${client.funcs.toTitleCase(missing.join(", ").split("_").join(" "))}**`, "error");
       return true;
     }
     return `Insufficient permissions, missing: **${client.funcs.toTitleCase(missing.join(", ").split("_").join(" "))}**`;

--- a/src/inhibitors/missingBotPermissions.js
+++ b/src/inhibitors/missingBotPermissions.js
@@ -21,7 +21,7 @@ exports.conf = {
 exports.run = (client, msg, cmd) => {
   const missing = msg.channel.type === "text" ? msg.channel.permissionsFor(client.user).missing(cmd.conf.botPerms) : impliedPermissions.missing(cmd.conf.botPerms);
   if (missing.length > 0) {
-    if (missing.includes("READ_MESSAGE_HISTORY") || missing.includes("SEND_MESSAGES")) {
+    if (missing.includes("SEND_MESSAGES")) {
       client.emit("log", `[Channel: ${msg.channel.id}] Insufficient permissions, missing: **${client.funcs.toTitleCase(missing.join(", ").split("_").join(" "))}**`, "error");
       return true;
     }


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
n/a
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Prevents Komada from trying to send "Missing Permissions" message in a channel where it can't send any messages.
- Still requires users to put in the permissions in the commands botPerms array.
- Also fixes a caching issue in the New Settings that I overlooked

Fixes #352 (sort of)
