### PR TITLE
Remove performance-now in favor of native node performance now

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "fs-nextra": "^0.3.0",
     "moment": "^2.18.1",
-    "moment-duration-format": "^1.3.0",
-    "performance-now": "^2.1.0"
+    "moment-duration-format": "^1.3.0"
   },
   "peerDependencies": {
     "discord.js": "github:hydrabolt/discord.js"

--- a/src/classes/client.js
+++ b/src/classes/client.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-throw-literal, no-use-before-define, no-restricted-syntax, no-underscore-dangle */
 const Discord = require("discord.js");
 const path = require("path");
-const now = require("performance-now");
+const { performance: { now } } = require("perf_hooks");
 const CommandMessage = require("./commandMessage");
 const Loader = require("./loader");
 const ArgResolver = require("./argResolver");

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -1,4 +1,4 @@
-const now = require("performance-now");
+const { performance: { now } } = require("perf_hooks");
 
 exports.run = async (client, msg) => {
   if (!client.ready) return;

--- a/src/finalizers/commandlogging.js
+++ b/src/finalizers/commandlogging.js
@@ -1,4 +1,4 @@
-const now = require("performance-now");
+const { performance: { now } } = require("perf_hooks");
 
 const colors = {
   prompted: { message: { background: "red" } },


### PR DESCRIPTION
### Proposed Semver Increment Bump: [MAJOR/MINOR/PATCH]
PATCH because < 1.0.0
### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Remove performance-now in favor of native node performance now
-
-

### (If Applicable) What Issue does it fix?

 Fixes... 
