### PR TITLE
Fix message.awaitMessage to handle command prompting from DMs.

### DIFF
--- a/src/events/message.js
+++ b/src/events/message.js
@@ -85,10 +85,10 @@ exports.runCommand = (client, msg, start) => {
 
 /* eslint-disable no-throw-literal */
 exports.awaitMessage = async (client, msg, start, error) => {
-  const message = await msg.channel.send(`<@!${msg.member.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`)
+  const message = await msg.channel.send(`<@!${msg.author.id}> | **${error}** | You have **30** seconds to respond to this prompt with a valid argument. Type **"ABORT"** to abort this prompt.`)
     .catch((err) => { throw client.funcs.newError(err); });
 
-  const param = await msg.channel.awaitMessages(response => response.member.id === msg.author.id && response.id !== message.id, { max: 1, time: 30000, errors: ["time"] });
+  const param = await msg.channel.awaitMessages(response => response.author.id === msg.author.id && response.id !== message.id, { max: 1, time: 30000, errors: ["time"] });
   if (param.first().content.toLowerCase() === "abort") throw "Aborted";
   msg.args[msg.args.lastIndexOf(null)] = param.first().content;
   msg.reprompted = true;


### PR DESCRIPTION
### Proposed Semver Increment Bump: [PATCH]

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Command prompting wasn't working for required arguments in DMs.

### (If Applicable) What Issue does it fix?

 Fixes this thing where a command with required arguments would throw when in DMs instead of prompting the user.
